### PR TITLE
Add initial eIDAS support

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -16,6 +16,7 @@ from saml2.authn_context import requested_authn_context
 
 import satosa.util as util
 from satosa.base import SAMLBaseModule
+from satosa.base import SAMLEIDASBaseModule
 from .base import BackendModule
 from ..exception import SATOSAAuthenticationError
 from ..internal_data import (InternalResponse,
@@ -386,6 +387,36 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             entity_descriptions.append(description)
         return entity_descriptions
 
+
+class SAMLEIDASBackend(SAMLBackend, SAMLEIDASBaseModule):
+    """
+    A saml2 eidas backend module (acting as a SP).
+    """
+    VALUE_ACR_CLASS_REF_DEFAULT = 'http://eidas.europa.eu/LoA/high'
+    VALUE_ACR_COMPARISON_DEFAULT = 'minimum'
+
+    def init_config(self, config):
+        config = super().init_config(config)
+
+        spec_eidas_sp = {
+            'acr_mapping': {
+                "": {
+                    'class_ref': self.VALUE_ACR_CLASS_REF_DEFAULT,
+                    'comparison': self.VALUE_ACR_COMPARISON_DEFAULT,
+                },
+            },
+            'sp_config.service.sp.authn_requests_signed': True,
+            'sp_config.service.sp.want_response_signed': True,
+            'sp_config.service.sp.allow_unsolicited': False,
+            'sp_config.service.sp.force_authn': True,
+            'sp_config.service.sp.hide_assertion_consumer_service': True,
+            'sp_config.service.sp.sp_type': ['private', 'public'],
+            'sp_config.service.sp.sp_type_in_metadata': [True, False],
+        }
+
+        return util.check_set_dict_defaults(config, spec_eidas_sp)
+
+
 class SAMLInternalResponse(InternalResponse):
     """
     Like the parent InternalResponse, holds internal representation of
@@ -413,4 +444,3 @@ class SAMLInternalResponse(InternalResponse):
             _dict['name_id'] = None
 
         return _dict
-

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -3,9 +3,13 @@ The SATOSA main module
 """
 import json
 import logging
-from uuid import uuid4
+import uuid
 
+from saml2.s_utils import UnknownSystemEntity
+
+from satosa import util
 from satosa.micro_services import consent
+
 from .context import Context
 from .exception import SATOSAConfigurationError
 from .exception import SATOSAError, SATOSAAuthenticationError, SATOSAUnknownError
@@ -17,7 +21,6 @@ from .plugin_loader import load_backends, load_frontends
 from .plugin_loader import load_request_microservices, load_response_microservices
 from .routing import ModuleRouter, SATOSANoBoundEndpointError
 from .state import cookie_to_state, SATOSAStateError, State, state_to_cookie
-from saml2.s_utils import UnknownSystemEntity
 
 
 logger = logging.getLogger(__name__)
@@ -212,7 +215,7 @@ class SATOSABase(object):
         try:
             return spec(context)
         except SATOSAAuthenticationError as error:
-            error.error_id = uuid4().urn
+            error.error_id = uuid.uuid4().urn
             msg = "ERROR_ID [{err_id}]\nSTATE:\n{state}".format(err_id=error.error_id,
                                                                 state=json.dumps(
                                                                     error.state.state_dict,
@@ -298,3 +301,16 @@ class SAMLBaseModule(object):
     def expose_entityid_endpoint(self):
         value = self.config.get(self.KEY_ENTITYID_ENDPOINT, False)
         return bool(value)
+
+
+class SAMLEIDASBaseModule(SAMLBaseModule):
+    VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'eidas'
+
+    def init_config(self, config):
+        config = super().init_config(config)
+
+        spec_eidas = {
+            'entityid_endpoint': True,
+        }
+
+        return util.check_set_dict_defaults(config, spec_eidas)


### PR DESCRIPTION
This merge request adds a SAML **eIDAS** enabled backend - depends on rohe/pysaml2#437. 
By default, it enables settings as defined by the SAML eIDAS specification. 

To make things easier to check and set defaults, utility functions are defined that can look up and set nested dictionary attributes, and compare them with a given _spec_ where nested keys are given as strings concatenated with `.` (dot).

Example configuration:
```
module: satosa.backends.saml2.SAMLEIDASBackend
name: Saml2
config:
  attribute_profile: eidas

  # use entityid as an endpoint to serve the metadata xml document
  # by default set to true for SAMLEIDASBackend
  # entityid_endpoint: true

  # SP RequestAuthnContext
  # by default set to LoA/high with comparison minimum for SAMLEIDASBackend
  # acr_mapping:
  #   "": http://eidas.europa.eu/LoA/high

  sp_config:
    organization: ...
    contact_person: ...
    metadata: ...
    entityid: <base_url>/<name>/proxy_saml2_backend.xml
    key_file: pki/backend.key
    cert_file: pki/backend.crt

    service:
      sp:
        # SPType can be public or private
        sp_type: public
        # whether SPType should be part of the metadata
        # or part of each authn request
        sp_type_in_metadata: false

        # RequestedAttributes on AuthnRequest
        # by default requested attributes are required
        requested_attributes:
        - friendly_name: PersonIdentifier
        - name: http://eidas.europa.eu/attributes/naturalperson/DateOfBirth
        - friendly_name: PlaceOfBirth
          required: false

        # hide AssertionConsumerServiceURL and ProtocolBinding on AuthnRequest
        # by default set to true for SAMLEIDASBackend
        # hide_assertion_consumer_service: true

        # always force authentication -- ForceAutn="true"
        # by default set to true for SAMLEIDASBackend
        # force_authn: true

        # disallow unsolicited responses
        # by default set to false for SAMLEIDASBackend
        # allow_unsolicited: false

        # always sign authn requests
        # by default set to true for SAMLEIDASBackend
        # authn_requests_signed: true

        # require signed responses
        # by default set to true for SAMLEIDASBackend
        # want_response_signed: true

        endpoints:
          assertion_consumer_service:
          - [<base_url>/<name>/acs/post, 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']
          - [<base_url>/<name>/acs/redirect, 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
```

