### PR TITLE
Use latest pyoic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages('src/'),
     package_dir={'': 'src'},
     install_requires=[
-        "pyop==2.0.5",
+        "pyop",
         "pysaml2==4.5.0",
         "pycryptodomex",
         "requests",

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -73,6 +73,9 @@ class OpenIDConnectFrontend(FrontendModule):
             "scopes_supported": scopes_supported
         }
 
+        if 'code' in response_types_supported:
+            capabilities["token_endpoint"] = "{}/{}".format(endpoint_baseurl, TokenEndpoint.url)
+
         if self.config["provider"].get("client_registration_supported", False):
             capabilities["registration_endpoint"] = "{}/{}".format(endpoint_baseurl, RegistrationEndpoint.url)
 

--- a/tests/flows/test_saml-oidc.py
+++ b/tests/flows/test_saml-oidc.py
@@ -47,7 +47,7 @@ class TestSAMLToOIDC:
         id_token_claims["sub"] = user_id
         id_token_claims["iat"] = time.time()
         id_token_claims["exp"] = time.time() + 3600
-        id_token_claims["iss"] = "http://op.example.com"
+        id_token_claims["iss"] = "https://op.example.com"
         id_token_claims["aud"] = oidc_backend_config["config"]["client"]["client_metadata"]["client_id"]
         id_token_claims["nonce"] = parsed_auth_req["nonce"]
         id_token = IdToken(**id_token_claims).to_jwt()


### PR DESCRIPTION
Dependent on https://github.com/SUNET/pyop/pull/19.

One test is failing due to new pyoic is forcing token endpoint to be set when validation a providers configuration and the failing test checks that there should not be a token endpoint set for implicit flow.

Any insight to what is right to do here would be appreciated.