### PR TITLE
Allow scopes to be added to the authz request: e.g. facebook email

### DIFF
--- a/src/satosa/backends/oauth.py
+++ b/src/satosa/backends/oauth.py
@@ -52,12 +52,14 @@ class _OAuthBackend(BackendModule):
         self.redirect_url = "%s/%s" % (self.config["base_url"], self.config["authz_page"])
         self.external_type = external_type
         self.user_id_attr = user_id_attr
+        scope = self.config["scope"] if "scope" in self.config else ""
         self.consumer = Consumer(
             session_db=None,
             client_config=self.config["client_config"],
             server_info=self.config["server_info"],
             authz_page=self.config["authz_page"],
-            response_type=self.config["response_type"])
+            response_type=self.config["response_type"],
+            scope=scope)
         self.consumer.client_secret = self.config["client_secret"]
 
     def start_auth(self, context, internal_request, get_state=stateID):

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -149,6 +149,12 @@ class SATOSABase(object):
                              for v in internal_attributes[attribute]]
                 internal_attributes[attribute] = hashed_values
 
+        # FOX UW
+        # For myplan we have to fixup the uid value ( yes it's a hack )
+        uid_hack = self.config["INTERNAL_ATTRIBUTES"].get("myplan_uid_hack", None)
+        if uid_hack:
+            internal_attributes['uid'][0] = uid_hack % (internal_attributes['uid'][0])
+
         # remove all session state
         context.request = None
         context.state.delete = True

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -238,6 +238,9 @@ class SATOSABase(object):
                                     self.config["STATE_ENCRYPTION_KEY"])
         except SATOSAStateError:
             state = State()
+        # also catch bogus cookie
+        except ValueError:
+            state = State()
         context.state = state
 
     def _save_state(self, resp, context):

--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -123,7 +123,10 @@ class WsgiApplication(SATOSABase):
             if debug:
                 raise
 
-            resp = ServiceError("%s" % err)
+            if type(err) == UnknownSystemEntity:
+                resp = ServiceError("The application you are attempting to access is not registered for social logins.")
+            else:
+                resp = ServiceError("%s" % err)
             return resp(environ, start_response)
 
 


### PR DESCRIPTION
We want to be able to request scopes, e.g. email, in addition to the default, public information.  This is required to get email from facebook.