### PR TITLE
OIDC fixes

### DIFF
--- a/src/satosa/attribute_mapping.py
+++ b/src/satosa/attribute_mapping.py
@@ -95,7 +95,7 @@ class AttributeMapper(object):
 
             external_attribute_name = mapping[attribute_profile]
             attribute_values = self._collate_attribute_values_by_priority_order(external_attribute_name,
-                                                                                external_dict)
+                                                                                external_dict, attribute_profile)
             if attribute_values:  # Only insert key if it has some values
                 logger.debug("backend attribute '%s' mapped to %s" % (external_attribute_name,
                                                             internal_attribute_name))
@@ -106,10 +106,10 @@ class AttributeMapper(object):
         internal_dict = self._handle_template_attributes(attribute_profile, internal_dict)
         return internal_dict
 
-    def _collate_attribute_values_by_priority_order(self, attribute_names, data):
+    def _collate_attribute_values_by_priority_order(self, attribute_names, data, profile):
         result = []
         for attr_name in attribute_names:
-            attr_val = self._get_nested_attribute_value(attr_name, data)
+            attr_val = self._get_nested_attribute_value(attr_name, data, profile)
 
             if isinstance(attr_val, list):
                 result.extend(attr_val)
@@ -145,8 +145,11 @@ class AttributeMapper(object):
 
         return internal_dict
 
-    def _get_nested_attribute_value(self, nested_key, data):
-        keys = nested_key.split(self.separator)
+    def _get_nested_attribute_value(self, nested_key, data, profile):
+        if (profile == 'openid'):
+            keys = nested_key.split(self.separator)
+        else:
+            keys = [nested_key]
 
         d = data
         for key in keys:

--- a/tests/flows/test_oidc-saml.py
+++ b/tests/flows/test_oidc-saml.py
@@ -97,4 +97,4 @@ class TestOIDCToSAML:
         signing_key = RSAKey(key=rsa_load(oidc_frontend_config["config"]["signing_key_path"]),
                              use="sig", alg="RS256")
         id_token_claims = JWS().verify_compact(resp_dict["id_token"], keys=[signing_key])
-        assert all((k, v[0]) in id_token_claims.items() for k, v in USERS[user_id].items())
+        assert all((k, v) in {ck:cv if isinstance(cv,list) else [cv] for ck, cv in id_token_claims.items()}.items() for k, v in USERS[user_id].items())


### PR DESCRIPTION
While working with SATOSA for our project we bumped against multiple tiny OIDC bugs, which are conveniently cherry picked in this pull-request.
In order of appearance:
1. Only split nested attributes for oidc based profiles, this borked oid based saml attribute processing.
2. Create token_endpoint if code is supported response type, as is implied.
3. Use all incoming values for outgoing OIDC claims, may violate OIDC single valuedness of claims
4. Whitespace, automatically removed by editor.
5. Correctly extend requested OIDC sub-attributes like address.street_address