### PR TITLE
fix issue 164: IE11 STATE_ENCRYPTION_KEY decode error

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -225,17 +225,23 @@ class SATOSABase(object):
 
     def _load_state(self, context):
         """
-        Load a state to the context
+        Load state from cookie to the context
 
         :type context: satosa.context.Context
         :param context: Session context
         """
         try:
-            state = cookie_to_state(context.cookie, self.config["COOKIE_STATE_NAME"],
-                                    self.config["STATE_ENCRYPTION_KEY"])
-        except SATOSAStateError:
+            state = cookie_to_state(
+                    context.cookie,
+                    self.config["COOKIE_STATE_NAME"],
+                    self.config["STATE_ENCRYPTION_KEY"])
+        except SATOSAStateError as e:
+            msg_tmpl = 'Failed to decrypt state {state} with {error}'
+            msg = msg_tmpl.format(state=context.cookie, error=str(e))
+            satosa_logging(logger, logging.WARNING, msg, None)
             state = State()
-        context.state = state
+        finally:
+            context.state = state
 
     def _save_state(self, resp, context):
         """

--- a/src/satosa/state.py
+++ b/src/satosa/state.py
@@ -69,13 +69,23 @@ def cookie_to_state(cookie_str, name, encryption_key):
     :return: A state
     """
     try:
-        state = State(SimpleCookie(cookie_str)[name].value, encryption_key)
-        satosa_logging(logger, logging.DEBUG, "Loading state from cookie: %s" % cookie_str, state)
+        cookie = SimpleCookie(cookie_str)
+        state = State(cookie[name].value, encryption_key)
+    except KeyError as e:
+        msg_tmpl = 'No cookie named {name} in {data}'
+        msg = msg_tmpl.format(name=name, data=cookie_str)
+        logger.exception(msg)
+        raise SATOSAStateError(msg) from e
+    except ValueError as e:
+        msg_tmpl = 'Failed to process {name} from {data}'
+        msg = msg_tmpl.format(name=name, data=cookie_str)
+        logger.exception(msg)
+        raise SATOSAStateError(msg) from e
+    else:
+        msg_tmpl = 'Loading state from cookie {data}'
+        msg = msg_tmpl.format(data=cookie_str)
+        satosa_logging(logger, logging.DEBUG, msg, state)
         return state
-    except KeyError:
-        logger.debug("Did not find cookie named '%s' in cookie string '%s'" % (name, cookie_str))
-        raise SATOSAStateError(
-            "No cookie named '{}' in cookie string '{}'".format(name, cookie_str))
 
 
 class _AESCipher(object):


### PR DESCRIPTION
Solution to #164  - For whatever reason decrypting the state cookie fails a WARNING message is logged and blank state initialized.