### PR TITLE
Add capability for common domain cookie

### DIFF
--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -54,3 +54,11 @@ config:
   endpoints:
     single_sign_on_service: {'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST': sso/post,
       'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect': sso/redirect}
+
+  # If configured and not false or empty the common domain cookie _saml_idp will be set
+  # with or have appended the IdP used for authentication. The default is not to set the
+  # cookie. If the value is a dictionary with key 'domain' then the domain for the cookie
+  # will be set to the value for the 'domain' key. If no 'domain' is set then the domain
+  # from the BASE defined for the proxy will be used.
+  common_domain_cookie:
+    domain: .example.com

--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -52,8 +52,9 @@ config:
     "https://accounts.google.com": LoA1
 
   endpoints:
-    single_sign_on_service: {'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST': sso/post,
-      'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect': sso/redirect}
+    single_sign_on_service:
+      'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST': sso/post
+      'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect': sso/redirect
 
   # If configured and not false or empty the common domain cookie _saml_idp will be set
   # with or have appended the IdP used for authentication. The default is not to set the

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -448,7 +448,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             satosa_logging(logger, logging.DEBUG, "Found existing common domain cookie {}".format(common_domain_cookie), context.state)
             space_separated_b64_idp_string = unquote(common_domain_cookie.value)
             b64_idp_list = space_separated_b64_idp_string.split()
-            idp_list = [ urlsafe_b64decode(b64_idp).decode('utf-8') for b64_idp in b64_idp_list ]
+            idp_list = [urlsafe_b64decode(b64_idp).decode('utf-8') for b64_idp in b64_idp_list]
         else:
             satosa_logging(logger, logging.DEBUG, "No existing common domain cookie found", context.state)
             idp_list = []
@@ -459,7 +459,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         this_flow_idp = internal_response.to_dict()['auth_info']['issuer']
 
         # Remove all occurrences of the current IdP from the list of IdPs.
-        idp_list = [ idp for idp in idp_list if idp != this_flow_idp ]
+        idp_list = [idp for idp in idp_list if idp != this_flow_idp]
 
         # Append the current IdP.
         idp_list.append(this_flow_idp)
@@ -467,7 +467,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         satosa_logging(logger, logging.DEBUG, "Common domain cookie list of IdPs is now {}".format(idp_list), context.state)
 
         # Construct the cookie.
-        b64_idp_list = [ urlsafe_b64encode(idp.encode()).decode("utf-8") for idp in idp_list ]
+        b64_idp_list = [urlsafe_b64encode(idp.encode()).decode("utf-8") for idp in idp_list]
         space_separated_b64_idp_string = " ".join(b64_idp_list)
         url_encoded_space_separated_b64_idp_string = quote(space_separated_b64_idp_string)
 


### PR DESCRIPTION
Add the capability to set the common domain cookie. See section
4.3.1 of
http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf.
The default remains to not set the cookie.