### PR TITLE
Improve and generalise routing error message

### DIFF
--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -115,7 +115,9 @@ class WsgiApplication(SATOSABase):
                 raise resp
             return resp(environ, start_response)
         except SATOSANoBoundEndpointError:
-            resp = NotFound("Couldn't find the page you asked for!")
+            resp = NotFound(
+                    "The Service or Identity Provider"
+                    "you requested could not be found.")
             return resp(environ, start_response)
         except Exception as err:
             if type(err) != UnknownSystemEntity:


### PR DESCRIPTION
A minor improvement on the error message displayed when no route to a frontend, backend or microservice is found. A bit more generalised, less technical, more user-friendly. 