### PR TITLE
Refactor target entity id

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -88,18 +88,18 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :rtype: satosa.response.Response
         """
 
+        target_entity_id = context.get_decoration(Context.KEY_TARGET_ENTITYID)
+        if target_entity_id:
+            entity_id = urlsafe_b64decode(target_entity_id).decode()
+            return self.authn_request(context, entity_id)
+
         # if there is only one IdP in the metadata, bypass the discovery service
         idps = self.sp.metadata.identity_providers()
         if len(idps) == 1 and "mdq" not in self.config["sp_config"]["metadata"]:
-            return self.authn_request(context, idps[0])
+            entity_id = idps[0]
+            return self.authn_request(context, entity_id)
 
-        entity_id = context.get_decoration(
-                Context.KEY_TARGET_ENTITYID)
-        if None is entity_id:
-            return self.disco_query()
-
-        entity_id = urlsafe_b64decode(entity_id).decode("utf-8")
-        return self.authn_request(context, entity_id)
+        return self.disco_query()
 
     def disco_query(self):
         """

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -94,7 +94,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             return self.authn_request(context, idps[0])
 
         entity_id = context.get_decoration(
-                Context.KEY_MIRROR_TARGET_ENTITYID)
+                Context.KEY_TARGET_ENTITYID)
         if None is entity_id:
             return self.disco_query()
 

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -5,7 +5,7 @@ import copy
 import functools
 import json
 import logging
-from base64 import urlsafe_b64encode, urlsafe_b64decode
+from base64 import urlsafe_b64encode
 from urllib.parse import urlparse
 
 from saml2.client_base import Base
@@ -90,7 +90,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         target_entity_id = context.get_decoration(Context.KEY_TARGET_ENTITYID)
         if target_entity_id:
-            entity_id = urlsafe_b64decode(target_entity_id).decode()
+            entity_id = target_entity_id
             return self.authn_request(context, entity_id)
 
         # if there is only one IdP in the metadata, bypass the discovery service

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -16,7 +16,7 @@ class Context(object):
     Holds information about the current request.
     """
     KEY_BACKEND_METADATA_STORE = 'metadata_store'
-    KEY_MIRROR_TARGET_ENTITYID = 'mirror_target_entity_id'
+    KEY_TARGET_ENTITYID = 'target_entity_id'
 
     def __init__(self):
         self._path = None

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -63,6 +63,10 @@ class Context(object):
             raise ValueError("path can't start with '/'")
         self._path = p
 
+    def target_entity_id_from_path(self):
+        target_entity_id = self.path.split("/")[1]
+        return target_entity_id
+
     def decorate(self, key, value):
         """
         Add information to the context

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -504,7 +504,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :param context:
         :return: An idp server
         """
-        target_entity_id = context.path.split("/")[1]
+        target_entity_id = context.target_entity_id_from_path()
         context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
         idp_conf_file = self._load_endpoints_to_config(context.target_backend, target_entity_id)
         idp_config = IdPConfig().load(idp_conf_file, metadata_construction=False)
@@ -549,7 +549,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :rtype: dict[str, dict[str, str] | str]
         """
         state = super()._create_state_data(context, resp_args, relay_state)
-        state["target_entity_id"] = context.path.split("/")[1]
+        state["target_entity_id"] = context.target_entity_id_from_path()
         return state
 
     def handle_backend_error(self, exception):

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -199,6 +199,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             satosa_logging(logger, logging.ERROR, "Could not find necessary info about entity: %s" % e, context.state)
             return ServiceError("Incorrect request from requester: %s" % e)
 
+        requester = resp_args["sp_entity_id"]
         context.state[self.name] = self._create_state_data(context, idp.response_args(authn_req),
                                                            context.request.get("RelayState"))
 
@@ -206,20 +207,19 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             name_format = saml_name_id_format_to_hash_type(authn_req.name_id_policy.format)
         else:
             # default to name id format from metadata, or just transient name id
-            name_format_from_metadata = idp.metadata[resp_args["sp_entity_id"]]["spsso_descriptor"][0].get(
-                "name_id_format")
+            name_format_from_metadata = idp.metadata[requester]["spsso_descriptor"][0].get("name_id_format")
             if name_format_from_metadata:
                 name_format = saml_name_id_format_to_hash_type(name_format_from_metadata[0]["text"])
             else:
                 name_format = UserIdHashType.transient
 
-        requester_name = self._get_sp_display_name(idp, resp_args["sp_entity_id"])
-        internal_req = InternalRequest(name_format, resp_args["sp_entity_id"], requester_name)
+        requester_name = self._get_sp_display_name(idp, requester)
+        internal_req = InternalRequest(name_format, requester, requester_name)
 
         idp_policy = idp.config.getattr("policy", "idp")
         if idp_policy:
-            approved_attributes = self._get_approved_attributes(idp, idp_policy, internal_req.requester, context.state)
-            internal_req.approved_attributes = approved_attributes
+            internal_req.approved_attributes = self._get_approved_attributes(
+                    idp, idp_policy, requester, context.state)
 
         return self.auth_req_callback_func(context, internal_req)
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -505,7 +505,6 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :return: An idp server
         """
         target_entity_id = context.target_entity_id_from_path()
-        context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
         idp_conf_file = self._load_endpoints_to_config(context.target_backend, target_entity_id)
         idp_config = IdPConfig().load(idp_conf_file, metadata_construction=False)
         return Server(config=idp_config)
@@ -535,6 +534,9 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :type binding_in: str
         :rtype: satosa.response.Response
         """
+        context.decorate(
+                Context.KEY_TARGET_ENTITYID,
+                context.target_entity_id_from_path())
         idp = self._load_idp_dynamic_endpoints(context)
         return self._handle_authn_request(context, binding_in, idp)
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import json
 import logging
+from base64 import urlsafe_b64decode
 from urllib.parse import urlparse
 
 from saml2 import SAMLError, xmldsig
@@ -534,9 +535,10 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :type binding_in: str
         :rtype: satosa.response.Response
         """
-        context.decorate(
-                Context.KEY_TARGET_ENTITYID,
-                context.target_entity_id_from_path())
+        target_entity_id = context.target_entity_id_from_path()
+        target_entity_id = urlsafe_b64decode(target_entity_id).decode()
+        context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
+
         idp = self._load_idp_dynamic_endpoints(context)
         return self._handle_authn_request(context, binding_in, idp)
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -505,7 +505,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :return: An idp server
         """
         target_entity_id = context.path.split("/")[1]
-        context.decorate(Context.KEY_MIRROR_TARGET_ENTITYID, target_entity_id)
+        context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
         idp_conf_file = self._load_endpoints_to_config(context.target_backend, target_entity_id)
         idp_config = IdPConfig().load(idp_conf_file, metadata_construction=False)
         return Server(config=idp_config)

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -58,8 +58,7 @@ class DecideIfRequesterIsAllowed(RequestMicroService):
         return urlsafe_b64encode(data.encode("utf-8")).decode("utf-8")
 
     def process(self, context, data):
-        target_entity_id = context.get_decoration(
-                Context.KEY_MIRROR_TARGET_ENTITYID)
+        target_entity_id = context.get_decoration(Context.KEY_TARGET_ENTITYID)
         if None is target_entity_id:
             logger.error("DecideIfRequesterIsAllowed can only be used with SAMLMirrorFrontend")
             raise SATOSAError("DecideIfRequesterIsAllowed can only be used with SAMLMirrorFrontend")

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -39,7 +39,9 @@ class DecideIfRequesterIsAllowed(RequestMicroService):
     """
     Decide whether a requester is allowed to send an authentication request to the target entity.
 
-    This micro service currently only works with `SAMLMirrorFrontend`.
+    This micro service currently only works when a target entityid is set.
+    Currently, a target entityid is set only when the `SAMLMirrorFrontend` is
+    used.
     """
     def __init__(self, config, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -60,8 +62,10 @@ class DecideIfRequesterIsAllowed(RequestMicroService):
     def process(self, context, data):
         target_entity_id = context.get_decoration(Context.KEY_TARGET_ENTITYID)
         if None is target_entity_id:
-            logger.error("DecideIfRequesterIsAllowed can only be used with SAMLMirrorFrontend")
-            raise SATOSAError("DecideIfRequesterIsAllowed can only be used with SAMLMirrorFrontend")
+            msg_tpl = "{name} can only be used when a target entityid is set"
+            msg = msg_tpl.format(name=self.__class__.__name__)
+            logger.error(msg)
+            raise SATOSAError(msg)
 
         target_specific_rules = self.rules.get(target_entity_id)
         # default to allowing everything if there are no specific rules

--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -146,7 +146,7 @@ class TestSAMLBackend:
         entityid = idp_conf["entityid"]
         entityid_bytes = entityid.encode("utf-8")
         entityid_b64_str = urlsafe_b64encode(entityid_bytes).decode("utf-8")
-        context.decorate(Context.KEY_MIRROR_TARGET_ENTITYID, entityid_b64_str)
+        context.decorate(Context.KEY_TARGET_ENTITYID, entityid_b64_str)
 
         resp = self.samlbackend.start_auth(context, InternalRequest(None, None))
         self.assert_redirect_to_idp(resp, idp_conf)

--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -144,9 +144,7 @@ class TestSAMLBackend:
     def test_start_auth_redirects_directly_to_mirrored_idp(
             self, context, idp_conf):
         entityid = idp_conf["entityid"]
-        entityid_bytes = entityid.encode("utf-8")
-        entityid_b64_str = urlsafe_b64encode(entityid_bytes).decode("utf-8")
-        context.decorate(Context.KEY_TARGET_ENTITYID, entityid_b64_str)
+        context.decorate(Context.KEY_TARGET_ENTITYID, entityid)
 
         resp = self.samlbackend.start_auth(context, InternalRequest(None, None))
         self.assert_redirect_to_idp(resp, idp_conf)

--- a/tests/satosa/micro_services/test_custom_routing.py
+++ b/tests/satosa/micro_services/test_custom_routing.py
@@ -14,7 +14,7 @@ TARGET_ENTITY = "entity1"
 def target_context(context):
     entityid_bytes = TARGET_ENTITY.encode("utf-8")
     entityid_b64_str = urlsafe_b64encode(entityid_bytes).decode("utf-8")
-    context.decorate(Context.KEY_MIRROR_TARGET_ENTITYID, entityid_b64_str)
+    context.decorate(Context.KEY_TARGET_ENTITYID, entityid_b64_str)
     return context
 
 


### PR DESCRIPTION
This changeset fixes the misconception that the `SAMLMirrorFrontend` is leaking information to the saml2 backend. This holds only by semantics - the name of the key set in the `context` object contains `_MIRROR_`. There is no direct relation to the `SAMLMirrorFrontend`. The key could be named anything.

The changeset renames the key to a more generic form. The key is handled by the context. The context defines the _environment_ inside which the backend will run. The backend checks the environment and if the key/flag is set, it acts accordingly.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?