### PR TITLE
Add verify_ssl option to OIDC backend

### DIFF
--- a/example/plugins/backends/openid_backend.yaml.example
+++ b/example/plugins/backends/openid_backend.yaml.example
@@ -4,6 +4,7 @@ config:
   provider_metadata:
     issuer: https://op.example.com
   client:
+    verify_ssl: yes
     auth_req_params:
       response_type: code
       scope: [openid, profile, email, address, phone]

--- a/src/satosa/backends/openid_connect.py
+++ b/src/satosa/backends/openid_connect.py
@@ -52,7 +52,11 @@ class OpenIDConnectBackend(BackendModule):
         super().__init__(auth_callback_func, internal_attributes, base_url, name)
         self.auth_callback_func = auth_callback_func
         self.config = config
-        self.client = _create_client(config["provider_metadata"], config["client"]["client_metadata"])
+        self.client = _create_client(
+            config["provider_metadata"],
+            config["client"]["client_metadata"],
+            config["client"].get("verify_ssl", True),
+        )
         if "scope" not in config["client"]["auth_req_params"]:
             config["auth_req_params"]["scope"] = "openid"
         if "response_type" not in config["client"]["auth_req_params"]:
@@ -230,7 +234,7 @@ class OpenIDConnectBackend(BackendModule):
         return get_metadata_desc_for_oauth_backend(self.config["provider_metadata"]["issuer"], self.config)
 
 
-def _create_client(provider_metadata, client_metadata):
+def _create_client(provider_metadata, client_metadata, verify_ssl=True):
     """
     Create a pyoidc client instance.
     :param provider_metadata: provider configuration information
@@ -240,7 +244,9 @@ def _create_client(provider_metadata, client_metadata):
     :return: client instance to use for communicating with the configured provider
     :rtype: oic.oic.Client
     """
-    client = oic.Client(client_authn_method=CLIENT_AUTHN_METHOD)
+    client = oic.Client(
+        client_authn_method=CLIENT_AUTHN_METHOD, verify_ssl=verify_ssl
+    )
 
     # Provider configuration information
     if "authorization_endpoint" in provider_metadata:


### PR DESCRIPTION
This changeset allows a user to configure the OIDC client in a way that disables SSL certificate verification; thus allowing hosts with self-signed certificates to work fine.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


