### PR TITLE
Do not send NameID with no TextContent

### DIFF
--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -308,24 +308,21 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
                 ava.pop(k, None)
 
         nameid_value = internal_response.subject_id
+        nameid_format = subject_type_to_saml_nameid_format(
+            internal_response.subject_type
+        )
 
         # If the backend did not receive a SAML <NameID> and so
         # name_id is set to None then do not create a NameID instance.
         # Instead pass None as the name name_id to the IdP server
         # instance and it will use its configured policy to construct
         # a <NameID>, with the default to create a transient <NameID>.
-        if nameid_value is None:
-            name_id = None
-        else:
-            nameid_format = subject_type_to_saml_nameid_format(
-                internal_response.subject_type
-            )
-            name_id = NameID(
-                text=nameid_value,
-                format=nameid_format,
-                sp_name_qualifier=None,
-                name_qualifier=None,
-            )
+        name_id = None if not nameid_value else NameID(
+            text=nameid_value,
+            format=nameid_format,
+            sp_name_qualifier=None,
+            name_qualifier=None,
+        )
 
         dbgmsg = "returning attributes %s" % json.dumps(ava)
         satosa_logging(logger, logging.DEBUG, dbgmsg, context.state)

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -308,15 +308,24 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
                 ava.pop(k, None)
 
         nameid_value = internal_response.subject_id
-        nameid_format = subject_type_to_saml_nameid_format(
-            internal_response.subject_type
-        )
-        name_id = NameID(
-            text=nameid_value,
-            format=nameid_format,
-            sp_name_qualifier=None,
-            name_qualifier=None,
-        )
+
+        # If the backend did not receive a SAML <NameID> and so
+        # name_id is set to None then do not create a NameID instance.
+        # Instead pass None as the name name_id to the IdP server
+        # instance and it will use its configured policy to construct
+        # a <NameID>, with the default to create a transient <NameID>.
+        if nameid_value is None:
+            name_id = None
+        else:
+            nameid_format = subject_type_to_saml_nameid_format(
+                internal_response.subject_type
+            )
+            name_id = NameID(
+                text=nameid_value,
+                format=nameid_format,
+                sp_name_qualifier=None,
+                name_qualifier=None,
+            )
 
         dbgmsg = "returning attributes %s" % json.dumps(ava)
         satosa_logging(logger, logging.DEBUG, dbgmsg, context.state)


### PR DESCRIPTION
Fix to the SAMLFrontend so that it will not create and return to the SP
a SAML `<NameID>` that has no `TextContent`, since that is not valid
SAML.

Fixes #199.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


