### PR TITLE
Support multiple scopes

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -9,3 +9,7 @@ config:
     response_types_supported: ["code", "id_token token"]
     subject_types_supported: ["pairwise"]
     scopes_supported: ["openid", "email"]
+    extra_scopes:
+      foo_scope:
+	  - bar_claim
+	  - baz_claim

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages('src/'),
     package_dir={'': 'src'},
     install_requires=[
-        "pyop",
+        "pyop >= 2.1.0",
         "pysaml2",
         "pycryptodomex",
         "requests",

--- a/tests/satosa/backends/test_openid_connect.py
+++ b/tests/satosa/backends/test_openid_connect.py
@@ -192,7 +192,11 @@ class TestOpenIDConnectBackend(object):
         auth_params = dict(parse_qsl(urlparse(auth_response.message).query))
 
         access_token = 12345
-        context.request = {"state": auth_params["state"], "access_token": access_token}
+        context.request = {
+            "state": auth_params["state"],
+            "access_token": access_token,
+            "token_type": "Bearer",
+        }
         self.oidc_backend.response_endpoint(context)
         assert self.oidc_backend.name not in context.state
         args = self.oidc_backend.auth_callback_func.call_args[0]


### PR DESCRIPTION
This changeset upgrade pyop to enable support for multiple scopes. A new configuration option for the OIDC/pyop provider is introduced `extra_scopes` that maps a scope to a list of claims.

This depends on IdentityPython/pyop#24 to be merged, and a new version of pyop to be released. Until then, this is intended to fail the travis tests with:

> No matching distribution found for pyop>=2.1.0 (from SATOSA==3.4.8)

---

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?