### PR TITLE
add session_not_on_or_after

### DIFF
--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import json
 import logging
+import datetime
 from base64 import urlsafe_b64decode
 from base64 import urlsafe_b64encode
 from urllib.parse import quote
@@ -336,6 +337,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         sign_response = sp_policy.get('sign_response', True)
         sign_alg = sp_policy.get('sign_alg', 'SIG_RSA_SHA256')
         digest_alg = sp_policy.get('digest_alg', 'DIGEST_SHA256')
+        session_not_on_or_after_minutes = sp_policy.get('session_not_on_or_after_minutes', {})
 
         # Construct arguments for method create_authn_response
         # on IdP Server instance
@@ -346,6 +348,11 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             'sign_response' : sign_response,
             'sign_assertion': sign_assertion,
         }
+
+        if session_not_on_or_after_minutes:
+            sessexp_utc = datetime.datetime.utcnow() + datetime.timedelta(minutes=session_not_on_or_after_minutes)
+            session_not_on_or_after = sessexp_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            args['session_not_on_or_after'] = session_not_on_or_after
 
         # Add the SP details
         args.update(**resp_args)
@@ -673,3 +680,4 @@ class SAMLMirrorFrontend(SAMLFrontend):
                                 functools.partial(self.handle_authn_request, binding_in=binding)))
 
         return url_map
+


### PR DESCRIPTION
Sets the session_not_on_or_after parameter in downstream assertions
when appropriately configured.

### All Submissions:

* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x ] Have you added an explanation of what problem you are trying to solve with this PR?
* [x ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


