### PR TITLE
[micro-service] Set target-issuer from disco response and decide backend by target-issuer

### DIFF
--- a/example/plugins/microservices/disco_to_target_issuer.yaml.example
+++ b/example/plugins/microservices/disco_to_target_issuer.yaml.example
@@ -1,0 +1,6 @@
+module: satosa.micro_services.disco.DiscoToTargetIssuer
+name: DiscoToTargetIssuer
+config:
+  # the regex that will intercept http requests to be handled with this microservice
+  disco_endpoints:
+    - ".*/disco"

--- a/example/plugins/microservices/target_based_routing.yaml.example
+++ b/example/plugins/microservices/target_based_routing.yaml.example
@@ -1,0 +1,12 @@
+module: satosa.micro_services.custom_routing.DecideBackendByTargetIdP
+name: TargetRouter
+config:
+  default_backend: Saml2
+
+  # the regex that will intercept http requests to be handled with this microservice
+  endpoint_paths:
+    - ".*/disco"
+
+  target_mapping:
+    "http://idpspid.testunical.it:8088": "spidSaml2" # map SAML entity with entity id 'target_id' to backend name
+    "http://eidas.testunical.it:8081/saml2/metadata": "eidasSaml2"

--- a/example/plugins/microservices/target_based_routing.yaml.example
+++ b/example/plugins/microservices/target_based_routing.yaml.example
@@ -1,11 +1,7 @@
-module: satosa.micro_services.custom_routing.DecideBackendByTargetIdP
+module: satosa.micro_services.custom_routing.DecideBackendByTargetIssuer
 name: TargetRouter
 config:
   default_backend: Saml2
-
-  # the regex that will intercept http requests to be handled with this microservice
-  endpoint_paths:
-    - ".*/disco"
 
   target_mapping:
     "http://idpspid.testunical.it:8088": "spidSaml2" # map SAML entity with entity id 'target_id' to backend name

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -7,20 +7,17 @@ from satosa.internal import InternalData
 from .base import RequestMicroService
 from ..exception import SATOSAConfigurationError
 from ..exception import SATOSAError
-from ..exception import SATOSAStateError
 
 
 logger = logging.getLogger(__name__)
 
 
 class CustomRoutingError(SATOSAError):
-    """
-    SATOSA exception raised by CustomRouting rules
-    """
+    """SATOSA exception raised by CustomRouting rules"""
     pass
 
 
-class DecideBackendByTargetIdP(RequestMicroService):
+class DecideBackendByTargetIssuer(RequestMicroService):
     """
     Select target backend based on the target issuer.
     """
@@ -38,14 +35,11 @@ class DecideBackendByTargetIdP(RequestMicroService):
         self.default_backend = config['default_backend']
 
     def process(self, context:Context, data:InternalData):
-        """
-        Set context.target_backend based on the target issuer (context.target_entity_id)
+        """Set context.target_backend based on the target issuer"""
 
-        :param context: request context
-        :param data: the internal request
-        """
         target_issuer = context.get_decoration(Context.KEY_TARGET_ENTITYID)
         if not target_issuer:
+            logger.info('skipping backend decision because no target_issuer was found')
             return super().process(context, data)
 
         target_backend = (
@@ -62,45 +56,6 @@ class DecideBackendByTargetIdP(RequestMicroService):
 
         context.target_backend = target_backend
         return super().process(context, data)
-
-
-class DecideBackendByDiscoIdP(DecideBackendByTargetIdP):
-    def __init__(self, config:dict, *args, **kwargs):
-        super().__init__(config, *args, **kwargs)
-
-        self.disco_endpoints = config['disco_endpoints']
-        if not isinstance(self.disco_endpoints, list):
-            raise CustomRoutingError('disco_endpoints must be a list of str')
-
-    def register_endpoints(self):
-        """
-        URL mapping of additional endpoints this micro service needs to register for callbacks.
-
-        Example of a mapping from the url path '/callback' to the callback() method of a micro service:
-            reg_endp = [
-                ("^/callback1$", self.callback),
-            ]
-
-        :rtype List[Tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]
-
-        :return: A list with functions and args bound to a specific endpoint url,
-                 [(regexp, Callable[[satosa.context.Context], satosa.response.Response]), ...]
-        """
-
-        return [
-            (path , self._handle_disco_response)
-            for path in self.disco_endpoints
-        ]
-
-    def _handle_disco_response(self, context:Context):
-        target_issuer_from_disco = context.request.get('entityID')
-        if not target_issuer_from_disco:
-            raise CustomRoutingError('no valid entity_id in the disco response')
-
-        context.decorate(Context.KEY_TARGET_ENTITYID, target_issuer_from_disco)
-        data_serialized = context.state.get(self.name, {}).get('internal', {})
-        data = InternalData.from_dict(data_serialized)
-        return self.process(context, data)
 
 
 class DecideBackendByRequester(RequestMicroService):

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -2,12 +2,121 @@ import logging
 from base64 import urlsafe_b64encode
 
 from satosa.context import Context
+from satosa.internal import InternalData
+
 from .base import RequestMicroService
 from ..exception import SATOSAConfigurationError
 from ..exception import SATOSAError
+from ..exception import SATOSAStateError
 
 
 logger = logging.getLogger(__name__)
+
+
+class CustomRoutingError(SATOSAError):
+    """
+    SATOSA exception raised by CustomRouting rules
+    """
+    pass
+
+
+class DecideBackendByTargetIdP(RequestMicroService):
+    """
+    Select which backend should be used based on who is the SAML IDP
+    """
+
+    def __init__(self, config:dict, *args, **kwargs):
+        """
+        Constructor.
+        :param config: microservice configuration loaded from yaml file
+        :type config: Dict[str, Dict[str, str]]
+        """
+        super().__init__(*args, **kwargs)
+        self.target_mapping = config['target_mapping']
+        self.endpoint_paths = config['endpoint_paths']
+        self.default_backend = config['default_backend']
+
+        if not isinstance(self.endpoint_paths, list):
+            raise SATOSAConfigurationError()
+
+    def register_endpoints(self):
+        """
+        URL mapping of additional endpoints this micro service needs to register for callbacks.
+
+        Example of a mapping from the url path '/callback' to the callback() method of a micro service:
+            reg_endp = [
+                ("^/callback1$", self.callback),
+            ]
+
+        :rtype List[Tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]
+
+        :return: A list with functions and args bound to a specific endpoint url,
+                 [(regexp, Callable[[satosa.context.Context], satosa.response.Response]), ...]
+        """
+
+        # this intercepts disco response
+        return [
+            (path , self.backend_by_entityid)
+            for path in self.endpoint_paths
+        ]
+
+    def _get_request_entity_id(self, context):
+        return (
+            context.get_decoration(Context.KEY_TARGET_ENTITYID) or
+            context.request.get('entityID')
+        )
+
+    def _get_backend(self, context:Context, entity_id:str) -> str:
+        """
+        returns the Target Backend to use
+        """
+        return (
+            self.target_mapping.get(entity_id) or
+            self.default_backend
+        )
+
+    def process(self, context:Context, data:dict):
+        """
+        Will modify the context.target_backend attribute based on the target entityid.
+        :param context: request context
+        :param data: the internal request
+        """
+        entity_id = self._get_request_entity_id(context)
+        if entity_id:
+            self._rewrite_context(entity_id, context)
+        return super().process(context, data)
+
+    def _rewrite_context(self, entity_id:str, context:Context) -> None:
+        tr_backend = self._get_backend(context, entity_id)
+        context.decorate(Context.KEY_TARGET_ENTITYID, entity_id)
+        context.target_frontend = context.target_frontend or context.state.get('ROUTER')
+        native_backend = context.target_backend
+        msg = (f'Found DecideBackendByTarget ({self.name} microservice) '
+               f'redirecting {entity_id} from {native_backend} '
+               f'backend to {tr_backend}')
+        logger.info(msg)
+        context.target_backend = tr_backend
+
+    def backend_by_entityid(self, context:Context):
+        entity_id = self._get_request_entity_id(context)
+
+        if entity_id:
+            self._rewrite_context(entity_id, context)
+        else:
+            raise CustomRoutingError(
+                f"{self.__class__.__name__} "
+                "can't find any valid entity_id in the context."
+            )
+
+        if not context.state.get('ROUTER'):
+            raise SATOSAStateError(
+                f"{self.__class__.__name__} "
+                "can't find any valid state in the context."
+            )
+
+        data_serialized = context.state.get(self.name, {}).get("internal", {})
+        data = InternalData.from_dict(data_serialized)
+        return super().process(context, data)
 
 
 class DecideBackendByRequester(RequestMicroService):

--- a/src/satosa/micro_services/disco.py
+++ b/src/satosa/micro_services/disco.py
@@ -1,0 +1,48 @@
+from satosa.context import Context
+from satosa.internal import InternalData
+
+from .base import RequestMicroService
+from ..exception import SATOSAError
+
+
+class DiscoToTargetIssuerError(SATOSAError):
+    """SATOSA exception raised by CustomRouting rules"""
+
+
+class DiscoToTargetIssuer(RequestMicroService):
+    def __init__(self, config:dict, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.disco_endpoints = config['disco_endpoints']
+        if not isinstance(self.disco_endpoints, list) or not self.disco_endpoints:
+            raise DiscoToTargetIssuerError('disco_endpoints must be a list of str')
+
+    def register_endpoints(self):
+        """
+        URL mapping of additional endpoints this micro service needs to register for callbacks.
+
+        Example of a mapping from the url path '/callback' to the callback() method of a micro service:
+            reg_endp = [
+                ('^/callback1$', self.callback),
+            ]
+
+        :rtype List[Tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]
+
+        :return: A list with functions and args bound to a specific endpoint url,
+                 [(regexp, Callable[[satosa.context.Context], satosa.response.Response]), ...]
+        """
+
+        return [
+            (path , self._handle_disco_response)
+            for path in self.disco_endpoints
+        ]
+
+    def _handle_disco_response(self, context:Context):
+        target_issuer = context.request.get('entityID')
+        if not target_issuer:
+            raise DiscoToTargetIssuerError('no valid entity_id in the disco response')
+
+        data_serialized = context.state.get(self.name, {}).get('internal_data', {})
+        data = InternalData.from_dict(data_serialized)
+        context.decorate(Context.KEY_TARGET_ENTITYID, target_issuer)
+        return super().process(context, data)

--- a/tests/satosa/micro_services/test_custom_routing.py
+++ b/tests/satosa/micro_services/test_custom_routing.py
@@ -1,13 +1,17 @@
 from base64 import urlsafe_b64encode
+from unittest import TestCase
 
 import pytest
 
 from satosa.context import Context
+from satosa.state import State
 from satosa.exception import SATOSAError, SATOSAConfigurationError, SATOSAStateError
 from satosa.internal import InternalData
 from satosa.micro_services.custom_routing import DecideIfRequesterIsAllowed
+from satosa.micro_services.custom_routing import DecideBackendByDiscoIdP
 from satosa.micro_services.custom_routing import DecideBackendByTargetIdP
 from satosa.micro_services.custom_routing import CustomRoutingError
+
 
 TARGET_ENTITY = "entity1"
 
@@ -160,61 +164,92 @@ class TestDecideIfRequesterIsAllowed:
             decide_service.process(context, req)
 
 
-class TestDecideBackendByTargetIdP:
-    rules = {
-        'default_backend': 'Saml2',
-        'endpoint_paths': ['.*/disco'],
-        'target_mapping': {'http://idpspid.testunical.it:8088': 'spidSaml2'}
-    }
+class TestDecideBackendByTargetIdP(TestCase):
+    def setUp(self):
+        context = Context()
+        context.state = State()
 
-    def create_decide_service(self, rules):
-        decide_service = DecideBackendByTargetIdP(
-                config=rules,
-                name="test_decide_service",
-                base_url="https://satosa.example.com"
+        config = {
+            'default_backend': 'default_backend',
+            'target_mapping': {
+                'mapped_idp.example.org': 'mapped_backend',
+            },
+            'disco_endpoints': [
+                '.*/disco',
+            ],
+        }
+
+        plugin = DecideBackendByTargetIdP(
+            config=config,
+            name='test_decide_service',
+            base_url='https://satosa.example.org',
         )
-        decide_service.next = lambda ctx, data: data
-        return decide_service
+        plugin.next = lambda ctx, data: (ctx, data)
+
+        self.config = config
+        self.context = context
+        self.plugin = plugin
+
+    def test_when_target_is_not_set_do_skip(self):
+        data = InternalData(requester='test_requester')
+        newctx, newdata = self.plugin.process(self.context, data)
+        assert not newctx.target_backend
+
+    def test_when_target_is_not_mapped_choose_default_backend(self):
+        self.context.decorate(Context.KEY_TARGET_ENTITYID, 'idp.example.org')
+        data = InternalData(requester='test_requester')
+        newctx, newdata = self.plugin.process(self.context, data)
+        assert newctx.target_backend == 'default_backend'
+
+    def test_when_target_is_mapped_choose_mapping_backend(self):
+        self.context.decorate(Context.KEY_TARGET_ENTITYID, 'mapped_idp.example.org')
+        data = InternalData(requester='test_requester')
+        data.requester = 'somebody else'
+        newctx, newdata = self.plugin.process(self.context, data)
+        assert newctx.target_backend == 'mapped_backend'
 
 
-    def test_missing_state(self, target_context):
-        decide_service = self.create_decide_service(self.rules)
-        target_context.request = {
-            'entityID': 'http://idpspid.testunical.it:8088',
+class TestDecideBackendByDiscoIdP(TestCase):
+    def setUp(self):
+        context = Context()
+        context.state = State()
+
+        config = {
+            'default_backend': 'default_backend',
+            'target_mapping': {
+                'mapped_idp.example.org': 'mapped_backend',
+            },
+            'disco_endpoints': [
+                '.*/disco',
+            ],
         }
-        req = InternalData(requester="test_requester")
-        req.requester = "somebody else"
-        assert decide_service.process(target_context, req)
 
-        with pytest.raises(SATOSAStateError):
-            decide_service.backend_by_entityid(target_context)
+        plugin = DecideBackendByDiscoIdP(
+            config=config,
+            name='test_decide_service',
+            base_url='https://satosa.example.org',
+        )
+        plugin.next = lambda ctx, data: (ctx, data)
 
+        self.config = config
+        self.context = context
+        self.plugin = plugin
 
-    def test_unmatching_target(self, target_context):
-        """
-            It would rely on the default backend
-        """
-        decide_service = self.create_decide_service(self.rules)
-        target_context.request = {
-            'entityID': 'unknow-entity-id',
+    def test_when_target_is_not_set_raise_error(self):
+        self.context.request = {}
+        with pytest.raises(CustomRoutingError):
+            self.plugin._handle_disco_response(self.context)
+
+    def test_when_target_is_not_mapped_choose_default_backend(self):
+        self.context.request = {
+            'entityID': 'idp.example.org',
         }
-        target_context.state['ROUTER'] = 'Saml2'
+        newctx, newdata = self.plugin._handle_disco_response(self.context)
+        assert newctx.target_backend == 'default_backend'
 
-        req = InternalData(requester="test_requester")
-        assert decide_service.process(target_context, req)
-
-        res = decide_service.backend_by_entityid(target_context)
-        assert isinstance(res, InternalData)
-
-    def test_matching_target(self, target_context):
-        decide_service = self.create_decide_service(self.rules)
-        target_context.request = {
-            'entityID': 'http://idpspid.testunical.it:8088-entity-id'
+    def test_when_target_is_mapped_choose_mapping_backend(self):
+        self.context.request = {
+            'entityID': 'mapped_idp.example.org',
         }
-        target_context.state['ROUTER'] = 'Saml2'
-
-        req = InternalData(requester="test_requester")
-        req.requester = "somebody else"
-        assert decide_service.process(target_context, req)
-        res = decide_service.backend_by_entityid(target_context)
-        assert isinstance(res, InternalData)
+        newctx, newdata = self.plugin._handle_disco_response(self.context)
+        assert newctx.target_backend == 'mapped_backend'

--- a/tests/satosa/micro_services/test_disco.py
+++ b/tests/satosa/micro_services/test_disco.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+import pytest
+
+from satosa.context import Context
+from satosa.state import State
+from satosa.micro_services.disco import DiscoToTargetIssuer
+from satosa.micro_services.disco import DiscoToTargetIssuerError
+
+
+class TestDiscoToTargetIssuer(TestCase):
+    def setUp(self):
+        context = Context()
+        context.state = State()
+
+        config = {
+            'disco_endpoints': [
+                '.*/disco',
+            ],
+        }
+
+        plugin = DiscoToTargetIssuer(
+            config=config,
+            name='test_disco_to_target_issuer',
+            base_url='https://satosa.example.org',
+        )
+        plugin.next = lambda ctx, data: (ctx, data)
+
+        self.config = config
+        self.context = context
+        self.plugin = plugin
+
+    def test_when_entity_id_is_not_set_raise_error(self):
+        self.context.request = {}
+        with pytest.raises(DiscoToTargetIssuerError):
+            self.plugin._handle_disco_response(self.context)
+
+    def test_when_entity_id_is_set_target_issuer_is_set(self):
+        entity_id = 'idp.example.org'
+        self.context.request = {
+            'entityID': entity_id,
+        }
+        newctx, newdata = self.plugin._handle_disco_response(self.context)
+        assert newctx.get_decoration(Context.KEY_TARGET_ENTITYID) == entity_id


### PR DESCRIPTION
Hello,
I developed a microservice that can map specific SaToSa backends to specific target entity id. A configuration example can be this:

````
module: satosa.micro_services.custom_routing.DecideBackendByTarget
name: TargetRouter
config:
  target_mapping:
    "http://idpspid.testunical.it:8088": "spidSaml2"
    "http://strangeIDP.testunical.it:8081/saml2/metadata": "strangeSaml2"
````

In the debug logs if the microservice has been activated we can read
````
[2019-04-14 23:01:29] [DEBUG]: [urn:uuid:acedce81-9287-4700-bd96-15b7adaeab5a] Routing path: Saml2/disco
[2019-04-14 23:01:29] [DEBUG]: [urn:uuid:acedce81-9287-4700-bd96-15b7adaeab5a] Found DecideBackendByTarget (TargetRouter microservice ) redirecting Saml2 backend to spidSaml2
````

I needed a backend routing based on the target entity ID because I have some SAML2 IDP that only accepts highly customized authn request and metadata. An example could be SPID italian federation. Another example could be the need to use different configurations, like sign and digest algorithms, depending by target IDP.

I was looking into DecideBackendByRequester microservice but soon I realized that it was made for different goals, in it the subjects are the requester entity ID and not the target entity ID.

This PR also answers to my  [related issue](https://github.com/IdentityPython/SATOSA/issues/219).

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


