### PR TITLE
Additional UnkownError informations to users

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -299,7 +299,7 @@ class SATOSABase(object):
         except Exception as err:
             satosa_logging(logger, logging.ERROR, "Uncaught exception", context.state,
                            exc_info=True)
-            raise SATOSAUnknownError("Unknown error") from err
+            raise SATOSAUnknownError("Unknown error: {}".format(err)) from err
         return resp
 
 


### PR DESCRIPTION
A little code change to have more eloquent UnknowError message, example:

Instead of
````
Unknown error
````
we have
````
Unknown error: name 'satosa_logging' is not defined
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


