### PR TITLE
[Documentation] Optional multiple user_id_from_attrs

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -187,7 +187,7 @@ class SATOSABase(object):
         # If configured construct the user id from attribute values.
         if "user_id_from_attrs" in self.config["INTERNAL_ATTRIBUTES"]:
             subject_id = [
-                "".join(internal_response.attributes[attr]) for attr in
+                "".join(internal_response.attributes.get(attr, '')) for attr in
                 self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]
             ]
             internal_response.subject_id = "".join(subject_id)


### PR DESCRIPTION
Hi,
I'm using SaToSa with two Saml Backends, through [this additional feature](https://github.com/IdentityPython/SATOSA/pull/220). These two Saml2 backends gets different attributes from their IDPs (target endpoint). If one of them do not return any  'eduPersonTargetedID' but another id with a different name, then SaToSa goes in Exception `Unknow Error` because it cannot find eduPersonTargetedID as attribute name.

Using this patch I can consider multiple uid, if anyone of them could be unavailable SaToSa will try another One, following this internal_attributes example:

````
user_id_from_attrs: ["edupersontargetedid", "eppn", "thatname"]
````

I share as it came, if you will like to spend some more word on this...
thank you in advance

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


