### PR TITLE
[satosa-saml-metadata] Load plugins from PWD

### DIFF
--- a/src/satosa/plugin_loader.py
+++ b/src/satosa/plugin_loader.py
@@ -190,6 +190,7 @@ def _load_endpoint_module(plugin_config, plugin_filter):
 
 
 def _load_plugin_module(plugin_config, plugin_filter):
+    sys.path.append('.') # permits to load plugins from PWD
     module_class = locate(plugin_config["module"])
     if not module_class:
         raise ValueError("Can't find module '%s'" % plugin_config["module"])


### PR DESCRIPTION
This PR permit us to have a custom backed stored in working directory instead of getting the following Exception:


````
satosa-saml-metadata proxy_conf.yaml ./pki/backend.key ./pki/backend.cert --split-backend

[....]

  File "/home/user/django-saml2-idp.env/lib/python3.7/site-packages/satosa/plugin_loader.py", line 195, in _load_plugin_module
    raise ValueError("Can't find module '%s'" % plugin_config["module"])
ValueError: Can't find module 'backends.spidsaml2.SpidSAMLBackend'
````

I have a custom backend called SpidSAMLBackend in a local folder, where the project configuration is.
Adding this simple line of code now I can get it to work

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


