### PR TITLE
Encrypt assertions in frontend authnresponse

### DIFF
--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -47,6 +47,8 @@ config:
             fail_on_missing_requested: false
             lifetime: {minutes: 15}
             name_form: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+            encrypt_assertion: false
+            encrypted_advice_attributes: false
   acr_mapping:
     "": default-LoA
     "https://accounts.google.com": LoA1

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -348,6 +348,8 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         sign_response = sp_policy.get('sign_response', True)
         sign_alg = sp_policy.get('sign_alg', 'SIG_RSA_SHA256')
         digest_alg = sp_policy.get('digest_alg', 'DIGEST_SHA256')
+        encrypt_assertion = sp_policy.get('encrypt_assertion', False)
+        encrypted_advice_attributes = sp_policy.get('encrypted_advice_attributes', False)
 
         # Construct arguments for method create_authn_response
         # on IdP Server instance
@@ -357,6 +359,8 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             'authn'         : auth_info,
             'sign_response' : sign_response,
             'sign_assertion': sign_assertion,
+            'encrypt_assertion': encrypt_assertion,
+            'encrypted_advice_attributes': encrypted_advice_attributes
         }
 
         # Add the SP details


### PR DESCRIPTION
With this PR we can encrypt assertion in authn response.
Optionally this behaviour can be configured in frontend idp policy as follow

````
[....]
        policy:
          default:
            attribute_restrictions: null
            fail_on_missing_requested: false
            lifetime: {minutes: 15}
            name_form: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
            sign_response: true
            sign_assertion: true

            encrypt_assertion: true
            encrypted_advice_attributes: true
````

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


