### PR TITLE
[Microservice] Multivalued fileds support in add static attributes 

### DIFF
--- a/src/satosa/micro_services/attribute_modifications.py
+++ b/src/satosa/micro_services/attribute_modifications.py
@@ -10,7 +10,9 @@ class AddStaticAttributes(ResponseMicroService):
 
     def __init__(self, config, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.static_attributes = config["static_attributes"]
+        self.static_attributes = dict()
+        for k,v in config["static_attributes"].items():
+            self.static_attributes[k] = [i.strip() for i in v.split(',')]
 
     def process(self, context, data):
         data.attributes.update(self.static_attributes)


### PR DESCRIPTION
With this PR I get this microservice to work with multi valued fields.
An example of plugin configuration is the following:

````
module: satosa.micro_services.attribute_modifications.AddStaticAttributes
name: AddAttributes
config:
    static_attributes:
        schachomeorganization: testunical.it
        schachomeorganizationtype: urn:schac:homeOrganizationType:eu:higherEducationInstitution, urn:schac:homeOrganizationType:eu:university
````



### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


