### PR TITLE
Refactor config attributes loading

### DIFF
--- a/src/satosa/satosa_config.py
+++ b/src/satosa/satosa_config.py
@@ -80,8 +80,12 @@ class SATOSAConfig(object):
             raise SATOSAConfigurationError("Missing configuration or unknown format")
 
         for key in SATOSAConfig.mandatory_dict_keys:
-            if key not in conf:
-                raise SATOSAConfigurationError("Missing key '%s' in config" % key)
+            if not conf.get(key, None):
+                raise SATOSAConfigurationError(
+                    "Missing key {key} or value for {key} in config".format(
+                        key=key
+                    )
+                )
 
         for key in SATOSAConfig.sensitive_dict_keys:
             if key not in conf and "SATOSA_{key}".format(key=key) not in os.environ:

--- a/tests/satosa/test_satosa_config.py
+++ b/tests/satosa/test_satosa_config.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import mock_open, patch
 
 import pytest
-from satosa.exception import SATOSAConfigurationError
 
 from satosa.exception import SATOSAConfigurationError
 from satosa.satosa_config import SATOSAConfig
@@ -15,8 +14,8 @@ class TestSATOSAConfig:
         config = {
             "BASE": "https://example.com",
             "COOKIE_STATE_NAME": "TEST_STATE",
-            "BACKEND_MODULES": [],
-            "FRONTEND_MODULES": [],
+            "BACKEND_MODULES": [{"foo": "bar"}],
+            "FRONTEND_MODULES": [{"foo": "bar"}],
             "INTERNAL_ATTRIBUTES": {"attributes": {}}
         }
         return config
@@ -73,3 +72,17 @@ class TestSATOSAConfig:
 
         with pytest.raises(SATOSAConfigurationError):
             SATOSAConfig(satosa_config_dict)
+
+    def test_missing_mandatory_dict_keys_raises_exception(self, satosa_config_dict):
+        for key in SATOSAConfig.mandatory_dict_keys:
+            patched_dict = satosa_config_dict
+            del patched_dict[key]
+            with pytest.raises(SATOSAConfigurationError):
+                SATOSAConfig(satosa_config_dict)
+
+    def test_empty_mandatory_dict_key_vals_raises_exception(self, satosa_config_dict):
+        for key in SATOSAConfig.mandatory_dict_keys:
+            patched_dict = satosa_config_dict
+            patched_dict[key] = None
+            with pytest.raises(SATOSAConfigurationError):
+                SATOSAConfig(satosa_config_dict)

--- a/tests/satosa/test_satosa_config.py
+++ b/tests/satosa/test_satosa_config.py
@@ -86,3 +86,20 @@ class TestSATOSAConfig:
             patched_dict[key] = None
             with pytest.raises(SATOSAConfigurationError):
                 SATOSAConfig(satosa_config_dict)
+
+    def test_can_skip_unset_microservices(self, satosa_config_dict):
+        satosa_config_dict["MICRO_SERVICES"] = None
+        config = SATOSAConfig(satosa_config_dict)
+        assert config["MICRO_SERVICES"] == []
+
+    def test_invalid_internal_attributes_raises_exception(self, satosa_config_dict):
+        satosa_config_dict["INTERNAL_ATTRIBUTES"] = ["dummy.yaml"]
+        expected_config = {}
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(expected_config))), \
+             pytest.raises(SATOSAConfigurationError):
+            SATOSAConfig(satosa_config_dict)
+
+    def test_invalid_conf_raises_exception(self):
+        with pytest.raises(SATOSAConfigurationError) as e:
+            SATOSAConfig({})


### PR DESCRIPTION
- Extends the validation of the mandatory_dict_keys in config by
checking that they also have a value. There is no point in having checks
for mandatory keys if they are empty (this would mean that they are not
really mandatory)
- Extracts `_parse_config` method to utilize for loading configs
- Moves the `self._config` check from `_verify_dict` method to beginning
of initialization. If the main config file is wrong, there's no need
proceeding any more
- Extracts plugin loading to `_load_plugins` method
- Fixes #184 by setting empty list as default value for plugin configs
in case a specific plugin config is unset thus allowing MICRO_SERVICES
plugin to be empty (instead of deleting the key)
- Adds test cases for invalid internal attributes and empty
MICRO_SERVICES plugin
- Adds test case for invalid conf although since the exception thrown is
generic for other config cases as well, the only way to verify this
is by checking the coverage (subclassing the config errors is probably a
better alternative)

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


