### PR TITLE
add explicit exception handling without traceback;

### DIFF
--- a/src/satosa/exception.py
+++ b/src/satosa/exception.py
@@ -10,7 +10,13 @@ class SATOSAError(Exception):
     pass
 
 
-class SATOSAConfigurationError(SATOSAError):
+class SATOSAErrorNoTraceback(SATOSAError):
+    """
+    Base SATOSA exception
+    """
+
+
+class SATOSAConfigurationError(SATOSAErrorNoTraceback):
     """
     SATOSA configuration error
     """

--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -9,6 +9,7 @@ import pkg_resources
 
 from .base import SATOSABase
 from .context import Context
+from .exception import SATOSAErrorNoTraceback
 from .response import ServiceError, NotFound
 from .routing import SATOSANoBoundEndpointError
 from saml2.s_utils import UnknownSystemEntity
@@ -119,12 +120,13 @@ class WsgiApplication(SATOSABase):
                     "The Service or Identity Provider"
                     "you requested could not be found.")
             return resp(environ, start_response)
-        except Exception as err:
-            if type(err) != UnknownSystemEntity:
-                logger.exception("%s" % err)
+        except UnknownSystemEntity:
             if debug:
                 raise
-
+        except SATOSAErrorNoTraceback as err:
+            logger.error(str(err))
+        except Exception as err:
+            logger.exception("%s" % err)
             resp = ServiceError("%s" % err)
             return resp(environ, start_response)
 

--- a/src/satosa/scripts/satosa_saml_metadata.py
+++ b/src/satosa/scripts/satosa_saml_metadata.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import click
 from saml2.config import Config
@@ -77,4 +78,8 @@ def create_and_write_saml_metadata(proxy_conf, key, cert, dir, valid, split_fron
 @click.option("--split-backend", is_flag=True, type=click.BOOL, default=False,
               help="Create one entity descriptor per file for the backend metadata")
 def construct_saml_metadata(proxy_conf, key, cert, dir, valid, split_frontend, split_backend):
-    create_and_write_saml_metadata(proxy_conf, key, cert, dir, valid, split_frontend, split_backend)
+    try:
+        create_and_write_saml_metadata(proxy_conf, key, cert, dir, valid, split_frontend, split_backend)
+    except Exception as e:
+        print('ERROR: ' + str(e), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Problem: SATOSA log includes traceback for errors that are sufficiently clear from the error message.
Tracebacks are difficult to handle for line-oriented logs and should be eliminated (but this will take time & effort)

This PR introduces SATOSAErrorNoTraceback and bases SATOSAConfigurationError on it.

The satosa_saml_metadata.py script gest extra code to suppress tracebacks.