### PR TITLE
Fix the examples for the attribute_generation micro_service

### DIFF
--- a/example/plugins/microservices/attribute_generation.yaml.example
+++ b/example/plugins/microservices/attribute_generation.yaml.example
@@ -2,8 +2,8 @@ module: satosa.micro_services.attribute_generation.AddSyntheticAttributes
 name: AddSyntheticAttributes
 config:
     synthetic_attributes:
-        target_provider1:
-            requester1:
+        requester1:
+            target_provider1:
                 eduPersonAffiliation: member;employee
         default:
             default:

--- a/src/satosa/micro_services/attribute_generation.py
+++ b/src/satosa/micro_services/attribute_generation.py
@@ -61,8 +61,8 @@ module: satosa.micro_services.attribute_generation.AddSyntheticAttributes
 name: AddSyntheticAttributes
 config:
     synthetic_attributes:
-        target_provider1:
-            requester1:
+        requester1:
+            target_provider1:
                 eduPersonAffiliation: member;employee
         default:
             default:
@@ -72,8 +72,8 @@ config:
 ```
 
 The use of "" and 'default' is synonymous. Attribute rules are not
-overloaded or inherited. For instance a response from "target_provider1"
-and requester1 in the above config will generate a (static) attribute
+overloaded or inherited. For instance a response for "requester1"
+from target_provider1 in the above config will generate a (static) attribute
 set of 'member' and 'employee' for the eduPersonAffiliation attribute
 and nothing else. Note that synthetic attributes override existing
 attributes if present.


### PR DESCRIPTION
In the example the ordering of target_provider and requester was the reverse from what is used in the code. Although, I believe that the ordering in the examples felt more intuitive, changing the ordering in the code would result to a breaking change for existing deployments.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


