### PR TITLE
Adds 3 new configuration options for the Facebook backend

### DIFF
--- a/example/plugins/backends/facebook_backend.yaml.example
+++ b/example/plugins/backends/facebook_backend.yaml.example
@@ -5,9 +5,16 @@ config:
   base_url: <base_url>
   client_config:
     client_id: <client_id>
+  # See https://developers.facebook.com/docs/facebook-login for
+  # information on valid values for auth_type
+  auth_type: []
+  scope: [public_profile, email]
   fields: [id, name, first_name, last_name, middle_name, picture, email, verified, gender, timezone, locale, updated_time]
   response_type: code
-  server_info: {authorization_endpoint: 'https://www.facebook.com/dialog/oauth', token_endpoint: 'https://graph.facebook.com/v2.5/oauth/access_token'}
+  server_info:
+    authorization_endpoint: 'https://www.facebook.com/dialog/oauth'
+    token_endpoint: 'https://graph.facebook.com/v3.3/oauth/access_token'
+    graph_endpoint: 'https://graph.facebook.com/v3.3/me'
   entity_info:
     organization:
       display_name:

--- a/src/satosa/backends/oauth.py
+++ b/src/satosa/backends/oauth.py
@@ -186,7 +186,7 @@ class FacebookBackend(_OAuthBackend):
     The default graph endpoint is for backward compatibility with previous versions of the
     Facebook backend in which the graph endpoint was hardcoded in the code.
     """
-    DEFAULT_GRAPH_ENDPOINT = 'https://graph.facebook.com/v2.5/me'
+    DEFAULT_GRAPH_ENDPOINT = "https://graph.facebook.com/v2.5/me"
 
     def __init__(self, outgoing, internal_attributes, config, base_url, name):
         """
@@ -248,7 +248,7 @@ class FacebookBackend(_OAuthBackend):
         :param access_token: The access token to be used to retrieve the data.
         :return: Dictionary with attribute name as key and attribute value as value.
         """
-        payload = {'access_token': access_token}
+        payload = {"access_token": access_token}
         url = self.config["server_info"].get("graph_endpoint", self.DEFAULT_GRAPH_ENDPOINT)
         if self.config["fields"]:
             payload["fields"] = ",".join(self.config["fields"])
@@ -282,14 +282,14 @@ def get_metadata_desc_for_oauth_backend(entity_id, config):
         # Add contact person information
         for contact_person in entity_info.get("contact_person", []):
             person = ContactPersonDesc()
-            if 'contact_type' in contact_person:
-                person.contact_type = contact_person['contact_type']
-            for address in contact_person.get('email_address', []):
+            if "contact_type" in contact_person:
+                person.contact_type = contact_person["contact_type"]
+            for address in contact_person.get("email_address", []):
                 person.add_email_address(address)
-            if 'given_name' in contact_person:
-                person.given_name = contact_person['given_name']
-            if 'sur_name' in contact_person:
-                person.sur_name = contact_person['sur_name']
+            if "given_name" in contact_person:
+                person.given_name = contact_person["given_name"]
+            if "sur_name" in contact_person:
+                person.sur_name = contact_person["sur_name"]
 
             description.add_contact_person(person)
 


### PR DESCRIPTION
The Facebook backend does not request any scopes from Facebook. As a
result, the default scope (public_profile) is assumed and the user is
asked to give permission only for that. This has the effect that even
though in the query to the Facebook graph API we might be asking for the
user's e-mail, the graph API will return only the user data that are
part of the public profile.

Furthermore, if a user has given permission for some scopes, then the
the user response is remembered by Facebook and even if the application
changes its configuration and requests for more scopes, Facebook will
not take this into account, unless the 'auth_type' parameter is set to
'rerequest'

This commit introduces three new configuration options:

- 'auth_type' expects list of auth_types. If none is provided, then the
'auth_type' parameter will not be sent to the authorization_endpoint.

- 'scope' expects a list of scopes. If none is provided, then the scope
element will not be added and 'public_profile' will be assumed (as it
happens now)

- 'graph_endpoint' expects the endpoint for the Facebook graph API. Up
to now the value of the graph_endpoint was hardcoded in the actual code
of the backend. In order to retain backwards compatibility if the
configuration option for the 'graph_endpoint' is not set, then it is
assumed to have the value that used to be hardcoded.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


