### PR TITLE
Closes #268: FB plugin example missing mandatory client_secret

### DIFF
--- a/example/plugins/backends/facebook_backend.yaml.example
+++ b/example/plugins/backends/facebook_backend.yaml.example
@@ -15,6 +15,7 @@ config:
     authorization_endpoint: 'https://www.facebook.com/dialog/oauth'
     token_endpoint: 'https://graph.facebook.com/v3.3/oauth/access_token'
     graph_endpoint: 'https://graph.facebook.com/v3.3/me'
+  client_secret: <client_secret>
   entity_info:
     organization:
       display_name:


### PR DESCRIPTION
### All Submissions:
This PR implements the quick fix outlined in #268, which is to add the `client_secret` field to [facebook_backend.yaml.example](https://github.com/IdentityPython/SATOSA/blob/afa985cbdfcb724781befef2e79633bcc7f9deb4/example/plugins/backends/facebook_backend.yaml.example). This is a simple fix that only affects the above example configuration file and does not touch the OAuth2 backend code.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


