### PR TITLE
Fixes support for extra_scopes in the OIDC frontend

### DIFF
--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -259,7 +259,11 @@ class OpenIDConnectFrontend(FrontendModule):
         return Response(self.provider.provider_configuration.to_json(), content="application/json")
 
     def _get_approved_attributes(self, provider_supported_claims, authn_req):
-        requested_claims = list(scope2claims(authn_req["scope"]).keys())
+        requested_claims = list(
+            scope2claims(
+                authn_req["scope"], self.config["provider"].get("extra_scopes")
+            ).keys()
+        )
         if "claims" in authn_req:
             for k in ["id_token", "userinfo"]:
                 if k in authn_req["claims"]:


### PR DESCRIPTION
`_get_approved_attributes` called `scope2claims` with one argument, the scopes the client had requested.

`scope2claims` can receive two arguments, the second being the `extra_scope_dict`. If that is not defined, then `scope2claims` will use only `SCOPE2CLAIMS`, which has only the `openid`,` profile`, `email`, `address`, `phone` and `offine`_access scopes.

This commit changes the call to scope2claims to include also the `extra_scopes` that may have been added in the Provider's configuration.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


