### PR TITLE
Add CO attribute scope to state for SAMLVirtualCoFrontend

### DIFF
--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -702,6 +702,7 @@ class SAMLVirtualCoFrontend(SAMLFrontend):
     KEY_CO_NAME = 'co_name'
     KEY_CO_ENTITY_ID = 'co_entity_id'
     KEY_CO_ATTRIBUTES = 'co_static_saml_attributes'
+    KEY_CO_ATTRIBUTE_SCOPE = 'co_attribute_scope'
     KEY_CONTACT_PERSON = 'contact_person'
     KEY_ENCODEABLE_NAME = 'encodeable_name'
     KEY_ORGANIZATION = 'organization'
@@ -773,6 +774,11 @@ class SAMLVirtualCoFrontend(SAMLFrontend):
         state[self.KEY_CO_NAME] = context.get_decoration(self.KEY_CO_NAME)
         state[self.KEY_CO_ENTITY_ID] = context.get_decoration(
                                                          self.KEY_CO_ENTITY_ID)
+
+        co_config = self._get_co_config(context)
+        state[self.KEY_CO_ATTRIBUTE_SCOPE] = co_config.get(
+                                                self.KEY_CO_ATTRIBUTE_SCOPE,
+                                                None)
 
         return state
 

--- a/tests/satosa/frontends/test_saml2.py
+++ b/tests/satosa/frontends/test_saml2.py
@@ -412,6 +412,7 @@ class TestSAMLVirtualCoFrontend(TestSAMLFrontend):
     CO_C = "countryname"
     CO_CO = "friendlycountryname"
     CO_NOREDUORGACRONYM = "noreduorgacronym"
+    CO_SCOPE = "messproject.org"
     CO_STATIC_SAML_ATTRIBUTES = {
         CO_O: ["Medium Energy Synchrotron Source"],
         CO_C: ["US"],
@@ -438,7 +439,8 @@ class TestSAMLVirtualCoFrontend(TestSAMLFrontend):
         # SAML attributes so their presence in a SAML Response can be tested.
         collab_org = {
             "encodeable_name": self.CO,
-            "co_static_saml_attributes": self.CO_STATIC_SAML_ATTRIBUTES
+            "co_static_saml_attributes": self.CO_STATIC_SAML_ATTRIBUTES,
+            "co_attribute_scope": self.CO_SCOPE
         }
 
         # Use the dynamically updated idp_conf fixture, the configured
@@ -490,6 +492,8 @@ class TestSAMLVirtualCoFrontend(TestSAMLFrontend):
 
         expected_entityid = "{}/{}".format(idp_conf['entityid'], self.CO)
         assert state[frontend.KEY_CO_ENTITY_ID] == expected_entityid
+
+        assert state[frontend.KEY_CO_ATTRIBUTE_SCOPE] == self.CO_SCOPE
 
     def test_get_co_name(self, frontend, context):
         co_name = frontend._get_co_name(context)


### PR DESCRIPTION
Add logic to store the configured CO attribute scope for an instance of
SAMLVirtualCoFrontend in the state so that microservices can easily
access it.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


