### PR TITLE
Allow definition of metadata URL for SAML plugins

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -151,7 +151,7 @@ Common configuration parameters:
 | `attribute_profile` | string | `saml` | attribute profile to use for mapping attributes from/to response
 | `entityid_endpoint` | bool | `true` | whether `entityid` should be used as a URL that serves the metadata xml document
 | `acr_mapping` | dict | `None` | custom Authentication Context Class Reference
-| `custom_metadata_url` | string | `custom_metadata/endpoint.xml` | custom metadata endpoint, in the case you want to serve your metadata on an endpoint other than the `entityId`s path. Will not get populated if the attribute is missing or empty, or when the `entityid_endpoint` property is not `true`.  |
+| `metadata_endpoint` | string | `my/metadata/endpoint.xml` | metadataendpoint, used for serving the metadata xml at a path of your choice. This config option acts independently from `entityid_endpoint`. |
 
 The metadata could be loaded in multiple ways in the table above it's loaded from a static
 file by using the key "local". It's also possible to load read the metadata from a remote URL.

--- a/doc/README.md
+++ b/doc/README.md
@@ -151,7 +151,7 @@ Common configuration parameters:
 | `attribute_profile` | string | `saml` | attribute profile to use for mapping attributes from/to response
 | `entityid_endpoint` | bool | `true` | whether `entityid` should be used as a URL that serves the metadata xml document
 | `acr_mapping` | dict | `None` | custom Authentication Context Class Reference
-| `metadata_endpoint` | string | `my/metadata/endpoint.xml` | metadataendpoint, used for serving the metadata xml at a path of your choice. This config option acts independently from `entityid_endpoint`. |
+| `metadata_endpoint` | string | `my/metadata/endpoint.xml` | metadata endpoint, used for serving the metadata xml at a path of your choice. This config option acts independently from `entityid_endpoint`. |
 
 The metadata could be loaded in multiple ways in the table above it's loaded from a static
 file by using the key "local". It's also possible to load read the metadata from a remote URL.

--- a/doc/README.md
+++ b/doc/README.md
@@ -151,6 +151,7 @@ Common configuration parameters:
 | `attribute_profile` | string | `saml` | attribute profile to use for mapping attributes from/to response
 | `entityid_endpoint` | bool | `true` | whether `entityid` should be used as a URL that serves the metadata xml document
 | `acr_mapping` | dict | `None` | custom Authentication Context Class Reference
+| `custom_metadata_url` | string | `custom_metadata/endpoint.xml` | custom metadata endpoint, in the case you want to serve your metadata on an endpoint other than the `entityId`s path. Will not get populated if the attribute is missing or empty, or when the `entityid_endpoint` property is not `true`.  |
 
 The metadata could be loaded in multiple ways in the table above it's loaded from a static
 file by using the key "local". It's also possible to load read the metadata from a remote URL.

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -452,11 +452,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
                 url_map.append(
                     ("^%s$" % parsed_endp.path[1:], self.disco_response))
 
-        if self.expose_entityid_endpoint():
-            parsed_entity_id = urlparse(self.sp.config.entityid)
-            url_map.append(("^{0}".format(parsed_entity_id.path[1:]),
-                            self._metadata_endpoint))
-
+        self.populate_entityid_urls(url_map, self.sp.config.entityid, self._metadata_endpoint)
         return url_map
 
     def get_metadata_desc(self):

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -307,7 +307,7 @@ class SATOSABase(object):
 
 class SAMLBaseModule(object):
     KEY_ENTITYID_ENDPOINT = 'entityid_endpoint'
-    KEY_METADATA_URL = 'custom_metadata_url'
+    KEY_METADATA_ENDPOINT = 'metadata_endpoint'
     KEY_ATTRIBUTE_PROFILE = 'attribute_profile'
     KEY_ACR_MAPPING = 'acr_mapping'
     VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'saml'
@@ -323,8 +323,8 @@ class SAMLBaseModule(object):
         value = self.config.get(self.KEY_ENTITYID_ENDPOINT, False)
         return bool(value)
 
-    def custom_metadata_url(self):
-        value = self.config.get(self.KEY_METADATA_URL, '')
+    def metadata_endpoint(self):
+        value = self.config.get(self.KEY_METADATA_ENDPOINT, '')
         return str(value)
 
     def populate_entityid_urls(self, url_map, entity_id, metadata_endpoint_fct):
@@ -339,10 +339,10 @@ class SAMLBaseModule(object):
             parsed_entity_id = urlparse(entity_id)
             url_map.append(("^{0}".format(parsed_entity_id.path[1:]),
                             metadata_endpoint_fct))
-            custom_metadata_url = self.custom_metadata_url()
-            if custom_metadata_url:
-                url_map.append(("^{0}".format(custom_metadata_url),
-                            metadata_endpoint_fct))
+        metadata_endpoint = self.metadata_endpoint()
+        if metadata_endpoint:
+            url_map.append(("^{0}".format(metadata_endpoint),
+                        metadata_endpoint_fct))
 
 class SAMLEIDASBaseModule(SAMLBaseModule):
     VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'eidas'

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -458,12 +458,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
                 parsed_endp = urlparse(endp)
                 url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
                                 functools.partial(self.handle_authn_request, binding_in=binding)))
-
-        if self.expose_entityid_endpoint():
-            parsed_entity_id = urlparse(self.idp.config.entityid)
-            url_map.append(("^{0}".format(parsed_entity_id.path[1:]),
-                            self._metadata_endpoint))
-
+        self.populate_entityid_urls(url_map, self.idp.config.entityid, self._metadata_endpoint)
         return url_map
 
     def _set_common_domain_cookie(self, internal_response, http_args, context):

--- a/src/satosa/routing.py
+++ b/src/satosa/routing.py
@@ -3,6 +3,7 @@ Holds satosa routing logic
 """
 import logging
 import re
+import pprint
 
 from satosa.context import SATOSABadContextError
 from satosa.exception import SATOSAError
@@ -38,6 +39,9 @@ class ModuleRouter(object):
     and handles the internal routing between frontends and backends.
     """
 
+    def __format_endpoint_urls(self, endpoints):
+        return pprint.pformat([{i : v['endpoints']} for i, v in endpoints.items()])
+
     def __init__(self, frontends, backends, micro_services):
         """
         :type frontends: dict[str, satosa.frontends.base.FrontendModule]
@@ -68,8 +72,8 @@ class ModuleRouter(object):
         else:
             self.micro_services = {}
 
-        logger.debug("Loaded backends with endpoints: {}".format(backends))
-        logger.debug("Loaded frontends with endpoints: {}".format(frontends))
+        logger.debug("Loaded backends with endpoints: {}".format(self.__format_endpoint_urls(self.backends)))
+        logger.debug("Loaded frontends with endpoints: {}".format(self.__format_endpoint_urls(self.frontends)))
         logger.debug("Loaded micro services with endpoints: {}".format(micro_services))
 
     def backend_routing(self, context):

--- a/tests/satosa/frontends/test_saml2.py
+++ b/tests/satosa/frontends/test_saml2.py
@@ -142,16 +142,16 @@ class TestSAMLFrontend:
         for endp in all_idp_endpoints:
             assert any(p.match(endp) for p in compiled_regex)
 
-    def test_register_endpoints_custom_url_mapping(self, idp_conf):
+    def test_register_endpoints_metadata_endpoint_mapping(self, idp_conf):
         """
-        Tests the method register_endpoints
+        Tests the method register_endpoints when a metadata_endpoint is defined
         """
-        custom_metadata_url = "potato/test"
+        metadata_endpoint = "potato/test"
         def get_path_from_url(url):
             return urlparse(url).path.lstrip("/")
 
         config = {"idp_config": idp_conf, "endpoints": ENDPOINTS, 
-            "custom_metadata_url": custom_metadata_url, "entityid_endpoint": True }
+            "metadata_endpoint": metadata_endpoint, "entityid_endpoint": True }
 
         base_url = self.construct_base_url_from_entity_id(idp_conf["entityid"])
         samlfrontend = SAMLFrontend(lambda context, internal_req: (context, internal_req),
@@ -160,7 +160,7 @@ class TestSAMLFrontend:
         providers = ["foo", "bar"]
         url_map = samlfrontend.register_endpoints(providers)
         compiled_regex = [re.compile(regex) for regex, _ in url_map]
-        assert any(p.match(custom_metadata_url) for p in compiled_regex)
+        assert any(p.match(metadata_endpoint) for p in compiled_regex)
 
     def test_handle_authn_request(self, context, idp_conf, sp_conf, internal_response):
         samlfrontend = self.setup_for_authn_req(context, idp_conf, sp_conf)

--- a/tests/satosa/frontends/test_saml2.py
+++ b/tests/satosa/frontends/test_saml2.py
@@ -142,6 +142,26 @@ class TestSAMLFrontend:
         for endp in all_idp_endpoints:
             assert any(p.match(endp) for p in compiled_regex)
 
+    def test_register_endpoints_custom_url_mapping(self, idp_conf):
+        """
+        Tests the method register_endpoints
+        """
+        custom_metadata_url = "potato/test"
+        def get_path_from_url(url):
+            return urlparse(url).path.lstrip("/")
+
+        config = {"idp_config": idp_conf, "endpoints": ENDPOINTS, 
+            "custom_metadata_url": custom_metadata_url, "entityid_endpoint": True }
+
+        base_url = self.construct_base_url_from_entity_id(idp_conf["entityid"])
+        samlfrontend = SAMLFrontend(lambda context, internal_req: (context, internal_req),
+                                    INTERNAL_ATTRIBUTES, config, base_url, "saml_frontend")
+
+        providers = ["foo", "bar"]
+        url_map = samlfrontend.register_endpoints(providers)
+        compiled_regex = [re.compile(regex) for regex, _ in url_map]
+        assert any(p.match(custom_metadata_url) for p in compiled_regex)
+
     def test_handle_authn_request(self, context, idp_conf, sp_conf, internal_response):
         samlfrontend = self.setup_for_authn_req(context, idp_conf, sp_conf)
         _, internal_req = samlfrontend.handle_authn_request(context, BINDING_HTTP_REDIRECT)


### PR DESCRIPTION
We at CERN require SAML metadata URLs to be different than the ones provided by parsing the `entityId`. This comes from a need to support an old and new system concurrently, both of them having the same `

This PR extends the config and allows it to be extended with a `custom_metadata_url`.