### PR TITLE
Set the CWD for gunicorn to $DATA_DIR

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -57,9 +57,9 @@ then chain_opts="--ca-certs chain.pem"
 fi
 
 # start the proxy
-exec gunicorn $conf_opt        \
+(cd $DATA_DIR; exec gunicorn $conf_opt        \
 	-b 0.0.0.0:"${PROXY_PORT}" \
 	satosa.wsgi:app            \
 	$https_opts                \
 	$chain_opts                \
-	;
+	;)

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -41,6 +41,7 @@ satosa-saml-metadata              \
 # if the user provided a gunicorn configuration, use it
 if [ -f "$GUNICORN_CONF" ]
 then conf_opt="--config ${GUNICORN_CONF}"
+else conf_opt="--chdir ${DATA_DIR}"
 fi
 
 # if HTTPS cert is available, use it
@@ -57,9 +58,9 @@ then chain_opts="--ca-certs chain.pem"
 fi
 
 # start the proxy
-(cd $DATA_DIR; exec gunicorn $conf_opt        \
+exec gunicorn $conf_opt        \
 	-b 0.0.0.0:"${PROXY_PORT}" \
 	satosa.wsgi:app            \
 	$https_opts                \
 	$chain_opts                \
-	;)
+	;


### PR DESCRIPTION
- Changes directory to $DATA_DIR to execute the gunicorn command in the
docker entry cmd script. This ensures that satosa will find
proxy_conf.yaml and the relevant files (plugins etc)
- Solves issue where docker image was broken after #278

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


