### PR TITLE
Log the absolute path when config file is not found

### DIFF
--- a/src/satosa/satosa_config.py
+++ b/src/satosa/satosa_config.py
@@ -144,7 +144,7 @@ class SATOSAConfig(object):
         :return: Loaded config
         """
         try:
-            with open(config_file) as f:
+            with open(os.path.abspath(config_file)) as f:
                 return yaml.safe_load(f.read())
         except yaml.YAMLError as exc:
             logger.error("Could not parse config as YAML: {}".format(exc))
@@ -152,6 +152,6 @@ class SATOSAConfig(object):
                 mark = exc.problem_mark
                 logger.error("Error position: ({line}:{column})".format(line=mark.line + 1, column=mark.column + 1))
         except IOError as e:
-            logger.debug("Could not open config file: {}".format(e))
+            logger.error("Could not open config file: {}".format(e))
 
         return None


### PR DESCRIPTION
config file not found  to be logged with severity error.
The file path should be absolute to explain relative path errors

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


