### PR TITLE
Add example file for custom_routing micro-service

### DIFF
--- a/example/plugins/microservices/custom_routing.yaml.example
+++ b/example/plugins/microservices/custom_routing.yaml.example
@@ -1,0 +1,11 @@
+module: satosa.micro_services.custom_routing.DecideIfRequesterIsAllowed
+name: RequesterDecider
+config:
+  rules:
+    target_entity_id1:
+        allow: ["requester1", "requester2"]
+    target_entity_id2:
+        deny: ["requester3"]
+    target_entity_id3:
+        allow: ["requester1"]
+        deny: ["*"]


### PR DESCRIPTION
an example has been missing so far.

Example limited to DecideIfRequesterIsAllowed function of the micro service
