### PR TITLE
Datafy the internal data structure

### DIFF
--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -79,12 +79,14 @@ class _Datafy(UserDict):
         return instance
 
 
-class AuthenticationInformation(object):
+class AuthenticationInformation(_Datafy):
     """
     Class that holds information about the authentication
     """
 
-    def __init__(self, auth_class_ref=None, timestamp=None, issuer=None):
+    def __init__(
+        self, auth_class_ref=None, timestamp=None, issuer=None, *args, **kwargs
+    ):
         """
         Initiate the data carrier
 
@@ -96,6 +98,7 @@ class AuthenticationInformation(object):
         :param timestamp: Time when the authentication was done
         :param issuer: Where the authentication was done
         """
+        super().__init__(self, *args, **kwargs)
         self.auth_class_ref = auth_class_ref
         self.timestamp = timestamp
         self.issuer = issuer
@@ -130,10 +133,17 @@ class AuthenticationInformation(object):
         return str(self.to_dict())
 
 
-class InternalData(object):
+class InternalData(_Datafy):
     """
     A base class for the data carriers between frontends/backends
     """
+
+    _DEPRECATED_TO_NEW_MEMBERS = {
+        "name_id": "subject_id",
+        "user_id": "subject_id",
+        "user_id_hash_type": "subject_type",
+        "approved_attributes": "attributes",
+    }
 
     def __init__(
         self,
@@ -147,6 +157,8 @@ class InternalData(object):
         user_id_hash_type=None,
         name_id=None,
         approved_attributes=None,
+        *args,
+        **kwargs,
     ):
         """
         :param auth_info:
@@ -171,6 +183,7 @@ class InternalData(object):
         :type name_id: str
         :type approved_attributes: dict
         """
+        super().__init__(self, *args, **kwargs)
         self.auth_info = auth_info or AuthenticationInformation()
         self.requester = requester
         self.requester_name = (
@@ -250,54 +263,6 @@ class InternalData(object):
             approved_attributes=data.get("approved_attributes"),
         )
         return instance
-
-    @property
-    def user_id(self):
-        msg = "user_id is deprecated; use subject_id instead."
-        _warnings.warn(msg, DeprecationWarning)
-        return self.subject_id
-
-    @user_id.setter
-    def user_id(self, value):
-        msg = "user_id is deprecated; use subject_id instead."
-        _warnings.warn(msg, DeprecationWarning)
-        self.subject_id = value
-
-    @property
-    def user_id_hash_type(self):
-        msg = "user_id_hash_type is deprecated; use subject_type instead."
-        _warnings.warn(msg, DeprecationWarning)
-        return self.subject_type
-
-    @user_id_hash_type.setter
-    def user_id_hash_type(self, value):
-        msg = "user_id_hash_type is deprecated; use subject_type instead."
-        _warnings.warn(msg, DeprecationWarning)
-        self.subject_type = value
-
-    @property
-    def approved_attributes(self):
-        msg = "approved_attributes is deprecated; use attributes instead."
-        _warnings.warn(msg, DeprecationWarning)
-        return self.attributes
-
-    @approved_attributes.setter
-    def approved_attributes(self, value):
-        msg = "approved_attributes is deprecated; use attributes instead."
-        _warnings.warn(msg, DeprecationWarning)
-        self.attributes = value
-
-    @property
-    def name_id(self):
-        msg = "name_id is deprecated; use subject_id instead."
-        _warnings.warn(msg, DeprecationWarning)
-        return self.subject_id
-
-    @name_id.setter
-    def name_id(self, value):
-        msg = "name_id is deprecated; use subject_id instead."
-        _warnings.warn(msg, DeprecationWarning)
-        self.subject_id = value
 
     def __repr__(self):
         return str(self.to_dict())

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -101,9 +101,7 @@ class InternalData(object):
         self.requester_name = (
             requester_name
             if requester_name is not None
-            else [
-                {"text": requester, "lang": "en"}
-            ]
+            else [{"text": requester, "lang": "en"}]
         )
         self.subject_id = (
             subject_id

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -155,7 +155,11 @@ class InternalData(_Datafy):
         :type approved_attributes: dict
         """
         super().__init__(self, *args, **kwargs)
-        self.auth_info = auth_info or AuthenticationInformation()
+        self.auth_info = (
+            auth_info
+            if isinstance(auth_info, AuthenticationInformation)
+            else AuthenticationInformation(**(auth_info or {}))
+        )
         self.requester = requester
         self.requester_name = (
             requester_name

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -103,35 +103,6 @@ class AuthenticationInformation(_Datafy):
         self.timestamp = timestamp
         self.issuer = issuer
 
-    def to_dict(self):
-        """
-        Converts an AuthenticationInformation object to a dict
-        :rtype: dict[str, str]
-        :return: A dict representation of the object
-        """
-        return {
-            "auth_class_ref": self.auth_class_ref,
-            "timestamp": self.timestamp,
-            "issuer": self.issuer,
-        }
-
-    @classmethod
-    def from_dict(cls, data):
-        """
-        :type data: dict[str, str]
-        :rtype: satosa.internal.AuthenticationInformation
-        :param data: A dict representation of an AuthenticationInformation object
-        :return: An AuthenticationInformation object
-        """
-        return cls(
-            auth_class_ref=data.get("auth_class_ref"),
-            timestamp=data.get("timestamp"),
-            issuer=data.get("issuer"),
-        )
-
-    def __repr__(self):
-        return str(self.to_dict())
-
 
 class InternalData(_Datafy):
     """
@@ -214,55 +185,3 @@ class InternalData(_Datafy):
             if approved_attributes is not None
             else {}
         )
-
-    def to_dict(self):
-        """
-        Converts an InternalData object to a dict
-        :rtype: dict[str, str]
-        :return: A dict representation of the object
-        """
-        data = {
-            "auth_info": self.auth_info.to_dict(),
-            "requester": self.requester,
-            "requester_name": self.requester_name,
-            "attributes": self.attributes,
-            "subject_id": self.subject_id,
-            "subject_type": self.subject_type,
-        }
-        data.update(
-            {
-                "user_id": self.subject_id,
-                "hash_type": self.subject_type,
-                "name_id": self.subject_id,
-                "approved_attributes": self.attributes,
-            }
-        )
-        return data
-
-    @classmethod
-    def from_dict(cls, data):
-        """
-        :type data: dict[str, str]
-        :rtype: satosa.internal.InternalData
-        :param data: A dict representation of an InternalData object
-        :return: An InternalData object
-        """
-        auth_info = AuthenticationInformation.from_dict(
-            data.get("auth_info", {})
-        )
-        instance = cls(
-            auth_info=auth_info,
-            requester=data.get("requester"),
-            requester_name=data.get("requester_name"),
-            subject_id=data.get("subject_id"),
-            subject_type=data.get("subject_type"),
-            attributes=data.get("attributes"),
-            user_id=data.get("user_id"),
-            user_id_hash_type=data.get("hash_type"),
-            name_id=data.get("name_id"),
-            approved_attributes=data.get("approved_attributes"),
-        )
-        return instance
-
-    def __repr__(self):
-        return str(self.to_dict())


### PR DESCRIPTION
Treat the objects under `satosa.interal` as dictionaries. 

This allows for transparency, easy extension and easy serialization.

We keep the type information of the objects, but behind the scenes we have a dictionary that is the foundation of the object and can be exposed by accessing `object.data`. The dictionary can be extended arbitrarily. If the values of the dictionary are complex objects, they should implement the `to_dict` method to allow for serialized versions of those values. Loading of serialized objects is done through the `from_dict` _class_-method which delegates the hard work to the initializer.


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?