### PR TITLE
Properly change the package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='SATOSA',
-    version='4.4.0',
+    version='4.5.1',
     description='Protocol proxy (SAML/OIDC).',
     author='DIRG',
     author_email='satosa-dev@lists.sunet.se',


### PR DESCRIPTION
On version `4.5.0` the package version indicator was not changed, but a corresponding branch was created. The version is now changed directly to `v4.5.1` to accommodate for the fix commit.