### PR TITLE
Deprecate the attribute interface for the internal objects

### DIFF
--- a/src/satosa/backends/github.py
+++ b/src/satosa/backends/github.py
@@ -95,10 +95,13 @@ class GitHubBackend(_OAuthBackend):
 
         user_info = self.user_information(response["access_token"])
         auth_info = self.auth_info(context.request)
-        internal_response = InternalData(auth_info=auth_info)
-        internal_response.attributes = self.converter.to_internal(
-            self.external_type, user_info)
-        internal_response.subject_id = str(user_info[self.user_id_attr])
+        internal_response = InternalData(
+            auth_info=auth_info,
+            attributes=self.converter.to_internal(
+                self.external_type, user_info
+            ),
+            subject_id=str(user_info[self.user_id_attr]),
+        )
         del context.state[self.name]
         return self.auth_callback_func(context, internal_response)
 

--- a/src/satosa/backends/linkedin.py
+++ b/src/satosa/backends/linkedin.py
@@ -96,10 +96,13 @@ class LinkedInBackend(_OAuthBackend):
 
         user_info = self.user_information(response["access_token"])
         auth_info = self.auth_info(context.request)
-        internal_response = InternalData(auth_info=auth_info)
-        internal_response.attributes = self.converter.to_internal(
-            self.external_type, user_info)
-        internal_response.subject_id = user_info[self.user_id_attr]
+        internal_response = InternalData(
+            auth_info=auth_info,
+            attributes=self.converter.to_internal(
+                self.external_type, user_info
+            ),
+            subject_id=user_info[self.user_id_attr],
+        )
         del context.state[self.name]
         return self.auth_callback_func(context, internal_response)
 

--- a/src/satosa/backends/oauth.py
+++ b/src/satosa/backends/oauth.py
@@ -142,9 +142,13 @@ class _OAuthBackend(BackendModule):
             self._verify_state(atresp, state_data, context.state)
 
         user_info = self.user_information(atresp["access_token"])
-        internal_response = InternalData(auth_info=self.auth_info(context.request))
-        internal_response.attributes = self.converter.to_internal(self.external_type, user_info)
-        internal_response.subject_id = user_info[self.user_id_attr]
+        internal_response = InternalData(
+            auth_info=self.auth_info(context.request),
+            attributes=self.converter.to_internal(
+                self.external_type, user_info
+            ),
+            subject_id=user_info[self.user_id_attr],
+        )
         del context.state[self.name]
         return self.auth_callback_func(context, internal_response)
 

--- a/src/satosa/backends/openid_connect.py
+++ b/src/satosa/backends/openid_connect.py
@@ -229,10 +229,13 @@ class OpenIDConnectBackend(BackendModule):
         :param subject_type: public or pairwise according to oidc standard.
         :return: A SATOSA internal response.
         """
-        auth_info = AuthenticationInformation(UNSPECIFIED, str(datetime.now()), issuer)
-        internal_resp = InternalData(auth_info=auth_info)
-        internal_resp.attributes = self.converter.to_internal("openid", response)
-        internal_resp.subject_id = response["sub"]
+        internal_resp = InternalData(
+            auth_info=AuthenticationInformation(
+                UNSPECIFIED, str(datetime.now()), issuer
+            ),
+            attributes=self.converter.to_internal("openid", response),
+            subject_id=response["sub"],
+        )
         return internal_resp
 
     def get_metadata_desc(self):

--- a/src/satosa/backends/orcid.py
+++ b/src/satosa/backends/orcid.py
@@ -73,12 +73,15 @@ class OrcidBackend(_OAuthBackend):
             request_args=rargs, state=aresp['state'])
 
         user_info = self.user_information(
-            atresp['access_token'], atresp['orcid'], atresp['name'])
+            atresp['access_token'], atresp['orcid'], atresp['name']
+        )
         internal_response = InternalData(
-            auth_info=self.auth_info(context.request))
-        internal_response.attributes = self.converter.to_internal(
-            self.external_type, user_info)
-        internal_response.subject_id = user_info[self.user_id_attr]
+            auth_info=self.auth_info(context.request),
+            attributes=self.converter.to_internal(
+                self.external_type, user_info
+            ),
+            subject_id=user_info[self.user_id_attr],
+        )
         del context.state[self.name]
         return self.auth_callback_func(context, internal_response)
 

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -125,7 +125,7 @@ class SATOSABase(object):
         :return: response
         """
         state = context.state
-        state[STATE_KEY] = {"requester": internal_request.requester}
+        state[STATE_KEY] = {"requester": internal_request["requester"]}
         # TODO consent module should manage any state it needs by itself
         try:
             state_dict = context.state[consent.STATE_KEY]
@@ -133,10 +133,10 @@ class SATOSABase(object):
             state_dict = context.state[consent.STATE_KEY] = {}
         finally:
             state_dict.update({
-                "filter": internal_request.attributes or [],
-                "requester_name": internal_request.requester_name,
+                "filter": internal_request["attributes"] or [],
+                "requester_name": internal_request["requester_name"],
             })
-        msg = "Requesting provider: {}".format(internal_request.requester)
+        msg = "Requesting provider: {}".format(internal_request["requester"])
         logline = lu.LOG_FMT.format(id=lu.get_session_id(state), message=msg)
         logger.info(logline)
 
@@ -153,11 +153,13 @@ class SATOSABase(object):
     def _auth_resp_finish(self, context, internal_response):
         user_id_to_attr = self.config["INTERNAL_ATTRIBUTES"].get("user_id_to_attr", None)
         if user_id_to_attr:
-            internal_response.attributes[user_id_to_attr] = [internal_response.subject_id]
+            internal_response["attributes"][user_id_to_attr] = [
+                internal_response["subject_id"]
+            ]
 
         hash_attributes(
             self.config["INTERNAL_ATTRIBUTES"].get("hash", []),
-            internal_response.attributes,
+            internal_response["attributes"],
             self.config.get("USER_ID_HASH_SALT", ""),
         )
 
@@ -183,19 +185,18 @@ class SATOSABase(object):
         """
 
         context.request = None
-        internal_response.requester = context.state[STATE_KEY]["requester"]
+        internal_response["requester"] = context.state[STATE_KEY]["requester"]
 
         # If configured construct the user id from attribute values.
         if "user_id_from_attrs" in self.config["INTERNAL_ATTRIBUTES"]:
             subject_id = [
-                "".join(internal_response.attributes[attr]) for attr in
+                "".join(internal_response["attributes"][attr]) for attr in
                 self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]
             ]
-            internal_response.subject_id = "".join(subject_id)
+            internal_response["subject_id"] = "".join(subject_id)
 
         if self.response_micro_services:
-            return self.response_micro_services[0].process(
-                context, internal_response)
+            return self.response_micro_services[0].process(context, internal_response)
 
         return self._auth_resp_finish(context, internal_response)
 

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -31,11 +31,33 @@ class _Datafy(UserDict):
         if key == "data":
             return super().__setattr__(key, value)
 
+        if not key.startswith("_"):
+            msg = " ".join(
+                [
+                    "Setting attributes on {cls} is deprecated;",
+                    "use the dict interface instead:",
+                    "Replace 'object.{key} = {value}'",
+                    "with 'object[\"{key}\"] = {value}'",
+                ]
+            ).format(cls=self.__class__, key=key, value=value)
+            _warnings.warn(msg, DeprecationWarning)
+
         self.__setitem__(key, value)
 
     def __getattr__(self, key):
         if key == "data":
             return self.data
+
+        if not key.startswith("_"):
+            msg = " ".join(
+                [
+                    "Getting attributes from {cls} is deprecated;",
+                    "use the dict interface instead:",
+                    "Replace 'object.{key}'",
+                    "with 'object.get(\"{key}\")'",
+                ]
+            ).format(cls=self.__class__, key=key)
+            _warnings.warn(msg, DeprecationWarning)
 
         try:
             value = self.__getitem__(key)

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -121,9 +121,9 @@ class AuthenticationInformation(_Datafy):
         :param issuer: Where the authentication was done
         """
         super().__init__(self, *args, **kwargs)
-        self.auth_class_ref = auth_class_ref
-        self.timestamp = timestamp
-        self.issuer = issuer
+        self.update(
+            {"auth_class_ref": auth_class_ref, "timestamp": timestamp, "issuer": issuer}
+        )
 
 
 class InternalData(_Datafy):
@@ -177,37 +177,41 @@ class InternalData(_Datafy):
         :type approved_attributes: dict
         """
         super().__init__(self, *args, **kwargs)
-        self.auth_info = (
-            auth_info
-            if isinstance(auth_info, AuthenticationInformation)
-            else AuthenticationInformation(**(auth_info or {}))
-        )
-        self.requester = requester
-        self.requester_name = (
-            requester_name
-            if requester_name is not None
-            else [{"text": requester, "lang": "en"}]
-        )
-        self.subject_id = (
-            subject_id
-            if subject_id is not None
-            else user_id
-            if user_id is not None
-            else name_id
-            if name_id is not None
-            else None
-        )
-        self.subject_type = (
-            subject_type
-            if subject_type is not None
-            else user_id_hash_type
-            if user_id_hash_type is not None
-            else None
-        )
-        self.attributes = (
-            attributes
-            if attributes is not None
-            else approved_attributes
-            if approved_attributes is not None
-            else {}
+        self.update(
+            {
+                "auth_info": (
+                    auth_info
+                    if isinstance(auth_info, AuthenticationInformation)
+                    else AuthenticationInformation(**(auth_info or {}))
+                ),
+                "requester": requester,
+                "requester_name": (
+                    requester_name
+                    if requester_name is not None
+                    else [{"text": requester, "lang": "en"}]
+                ),
+                "subject_id": (
+                    subject_id
+                    if subject_id is not None
+                    else user_id
+                    if user_id is not None
+                    else name_id
+                    if name_id is not None
+                    else None
+                ),
+                "subject_type": (
+                    subject_type
+                    if subject_type is not None
+                    else user_id_hash_type
+                    if user_id_hash_type is not None
+                    else None
+                ),
+                "attributes": (
+                    attributes
+                    if attributes is not None
+                    else approved_attributes
+                    if approved_attributes is not None
+                    else {}
+                ),
+            }
         )

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -50,14 +50,18 @@ class AccountLinking(ResponseMicroService):
         internal_response = InternalData.from_dict(saved_state)
 
         #subject_id here is the linked id , not the facebook one, Figure out what to do
-        status_code, message = self._get_uuid(context, internal_response.auth_info.issuer, internal_response.attributes['issuer_user_id'])
+        status_code, message = self._get_uuid(
+            context,
+            internal_response["auth_info"]["issuer"],
+            internal_response["attributes"]["issuer_user_id"],
+        )
 
         if status_code == 200:
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
-            internal_response.subject_id = message
+            internal_response["subject_id"] = message
             if self.id_to_attr:
-                internal_response.attributes[self.id_to_attr] = [message]
+                internal_response["attributes"][self.id_to_attr] = [message]
 
             del context.state[self.name]
             return super().process(context, internal_response)
@@ -84,22 +88,26 @@ class AccountLinking(ResponseMicroService):
         :
         """
 
-        status_code, message = self._get_uuid(context, internal_response.auth_info.issuer, internal_response.subject_id)
+        status_code, message = self._get_uuid(
+            context,
+            internal_response["auth_info"]["issuer"],
+            internal_response["subject_id"],
+        )
 
         data = {
-            "issuer": internal_response.auth_info.issuer,
+            "issuer": internal_response["auth_info"]["issuer"],
             "redirect_endpoint": "%s/account_linking%s" % (self.base_url, self.endpoint)
         }
 
         # Store the issuer subject_id/sub because we'll need it in handle_al_response
-        internal_response.attributes['issuer_user_id'] = internal_response.subject_id
+        internal_response["attributes"]["issuer_user_id"] = internal_response["subject_id"]
         if status_code == 200:
             satosa_logging(logger, logging.INFO, "issuer/id pair is linked in AL service",
                            context.state)
-            internal_response.subject_id = message
+            internal_response["subject_id"] = message
             data['user_id'] = message
             if self.id_to_attr:
-                internal_response.attributes[self.id_to_attr] = [message]
+                internal_response["attributes"][self.id_to_attr] = [message]
         else:
             satosa_logging(logger, logging.INFO, "issuer/id pair is not linked in AL service. Got a ticket",
                            context.state)

--- a/src/satosa/micro_services/attribute_authorization.py
+++ b/src/satosa/micro_services/attribute_authorization.py
@@ -60,5 +60,5 @@ structure above) are ORed together - i.e any attribute match is sufficient.
                     raise SATOSAAuthenticationError(context.state, "Permission denied")
 
     def process(self, context, data):
-        self._check_authz(context, data.attributes, data.requester, data.auth_info.issuer)
+        self._check_authz(context, data["attributes"], data["requester"], data["auth_info"]["issuer"])
         return super().process(context, data)

--- a/src/satosa/micro_services/attribute_generation.py
+++ b/src/satosa/micro_services/attribute_generation.py
@@ -28,8 +28,8 @@ class MustachAttrValue(object):
     @property
     def values(self):
         [{self._attr_name: v} for v in self._values]
-   
-    @property 
+
+    @property
     def value(self):
         if len(self._values) == 1:
            return self._values[0]
@@ -48,7 +48,7 @@ class MustachAttrValue(object):
         if self._scopes is not None:
            return self._scopes[0]
         return ""
-     
+
 
 class AddSyntheticAttributes(ResponseMicroService):
     """
@@ -124,15 +124,24 @@ you don't care which value is used in a template.
     def _synthesize(self, attributes, requester, provider):
         syn_attributes = dict()
         context = dict()
-        
-        for attr_name,values in attributes.items():
-           context[attr_name] = MustachAttrValue(attr_name, values)
+
+        for attr_name, values in attributes.items():
+            context[attr_name] = MustachAttrValue(attr_name, values)
 
         recipes = get_dict_defaults(self.synthetic_attributes, requester, provider)
         for attr_name, fmt in recipes.items():
-           syn_attributes[attr_name] = [v.strip().strip(';') for v in re.split("[;\n]+", pystache.render(fmt, context))]
+            syn_attributes[attr_name] = [
+                v.strip().strip(';')
+                for v in re.split("[;\n]+", pystache.render(fmt, context))
+            ]
         return syn_attributes
 
     def process(self, context, data):
-        data.attributes.update(self._synthesize(data.attributes, data.requester, data.auth_info.issuer))
+        data["attributes"].update(
+            self._synthesize(
+                data["attributes"],
+                data["requester"],
+                data["auth_info"]["issuer"],
+            )
+        )
         return super().process(context, data)

--- a/src/satosa/micro_services/attribute_modifications.py
+++ b/src/satosa/micro_services/attribute_modifications.py
@@ -13,7 +13,7 @@ class AddStaticAttributes(ResponseMicroService):
         self.static_attributes = config["static_attributes"]
 
     def process(self, context, data):
-        data.attributes.update(self.static_attributes)
+        data["attributes"].update(self.static_attributes)
         return super().process(context, data)
 
 
@@ -29,12 +29,16 @@ class FilterAttributeValues(ResponseMicroService):
     def process(self, context, data):
         # apply default filters
         provider_filters = self.attribute_filters.get("", {})
-        self._apply_requester_filters(data.attributes, provider_filters, data.requester)
+        self._apply_requester_filters(
+            data["attributes"],
+            provider_filters,
+            data["requester"],
+        )
 
         # apply target provider specific filters
-        target_provider = data.auth_info.issuer
+        target_provider = data["auth_info"]["issuer"]
         provider_filters = self.attribute_filters.get(target_provider, {})
-        self._apply_requester_filters(data.attributes, provider_filters, data.requester)
+        self._apply_requester_filters(data["attributes"], provider_filters, data["requester"])
         return super().process(context, data)
 
     def _apply_requester_filters(self, attributes, provider_filters, requester):

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -31,7 +31,7 @@ class DecideBackendByRequester(RequestMicroService):
         :param context: request context
         :param data: the internal request
         """
-        context.target_backend = self.requester_mapping[data.requester]
+        context.target_backend = self.requester_mapping[data["requester"]]
         return super().process(context, data)
 
 
@@ -72,27 +72,27 @@ class DecideIfRequesterIsAllowed(RequestMicroService):
         # default to allowing everything if there are no specific rules
         if not target_specific_rules:
             logger.debug("Requester '{}' allowed by default to target entity '{}' due to no entity specific rules".format(
-                data.requester, target_entity_id
+                data["requester"], target_entity_id
             ))
             return super().process(context, data)
 
         # deny rules takes precedence
         deny_rules = target_specific_rules.get("deny", [])
-        if data.requester in deny_rules:
+        if data["requester"] in deny_rules:
             logger.debug("Requester '{}' is not allowed by target entity '{}' due to deny rules '{}'".format(
-                data.requester, target_entity_id, deny_rules
+                data["requester"], target_entity_id, deny_rules
             ))
             raise SATOSAError("Requester is not allowed by target provider")
 
         allow_rules = target_specific_rules.get("allow", [])
         allow_all = "*" in allow_rules
-        if data.requester in allow_rules or allow_all:
+        if data["requester"] in allow_rules or allow_all:
             logger.debug("Requester '{}' allowed by target entity '{}' due to allow rules '{}".format(
-                data.requester, target_entity_id, allow_rules
+                data["requester"], target_entity_id, allow_rules
             ))
             return super().process(context, data)
 
         logger.debug("Requester '{}' is not allowed by target entity '{}' due to final deny all rule in '{}'".format(
-            data.requester, target_entity_id, deny_rules
+            data["requester"], target_entity_id, deny_rules
         ))
         raise SATOSAError("Requester is not allowed by target provider")

--- a/tests/satosa/backends/test_bitbucket.py
+++ b/tests/satosa/backends/test_bitbucket.py
@@ -111,10 +111,8 @@ class TestBitBucketBackend(object):
             "mail": [BB_USER_EMAIL_RESPONSE["values"][0]["email"]],
         }
 
-        context, internal_resp = self.bb_backend \
-            .auth_callback_func \
-            .call_args[0]
-        assert internal_resp.attributes == expected_attributes
+        context, internal_resp = self.bb_backend.auth_callback_func.call_args[0]
+        assert internal_resp["attributes"] == expected_attributes
 
     def assert_token_request(self, request_args, state, **kwargs):
         assert request_args["code"] == BB_RESPONSE_CODE
@@ -133,9 +131,7 @@ class TestBitBucketBackend(object):
             subject_type=NAMEID_FORMAT_TRANSIENT, requester='test_requester'
         )
 
-        resp = self.bb_backend.start_auth(context,
-                                          internal_request,
-                                          mock_get_state)
+        resp = self.bb_backend.start_auth(context, internal_request, mock_get_state)
         login_url = resp.message
         assert login_url.startswith(
                 BB_CONFIG["server_info"]["authorization_endpoint"])

--- a/tests/satosa/backends/test_oauth.py
+++ b/tests/satosa/backends/test_oauth.py
@@ -97,7 +97,7 @@ class TestFacebookBackend(object):
         }
 
         context, internal_resp = self.fb_backend.auth_callback_func.call_args[0]
-        assert internal_resp.attributes == expected_attributes
+        assert internal_resp["attributes"] == expected_attributes
 
     def assert_token_request(self, request_args, state, **kwargs):
         assert request_args["code"] == FB_RESPONSE_CODE

--- a/tests/satosa/backends/test_openid_connect.py
+++ b/tests/satosa/backends/test_openid_connect.py
@@ -153,8 +153,8 @@ class TestOpenIDConnectBackend(object):
 
     def test_translate_response_to_internal_response(self, internal_attributes, userinfo):
         internal_response = self.oidc_backend._translate_response(userinfo, ISSUER)
-        assert internal_response.subject_id == userinfo["sub"]
-        self.assert_expected_attributes(internal_attributes, userinfo, internal_response.attributes)
+        assert internal_response["subject_id"] == userinfo["sub"]
+        self.assert_expected_attributes(internal_attributes, userinfo, internal_response["attributes"])
 
     @responses.activate
     def test_response_endpoint(self, backend_config, internal_attributes, userinfo, signing_key, incoming_authn_response):
@@ -168,7 +168,7 @@ class TestOpenIDConnectBackend(object):
         args = self.oidc_backend.auth_callback_func.call_args[0]
         assert isinstance(args[0], Context)
         assert isinstance(args[1], InternalData)
-        self.assert_expected_attributes(internal_attributes, userinfo, args[1].attributes)
+        self.assert_expected_attributes(internal_attributes, userinfo, args[1]["attributes"])
 
     def test_start_auth_redirects_to_provider_authorization_endpoint(self, context, backend_config):
         auth_response = self.oidc_backend.start_auth(context, None)
@@ -200,7 +200,7 @@ class TestOpenIDConnectBackend(object):
         self.oidc_backend.response_endpoint(context)
         assert self.oidc_backend.name not in context.state
         args = self.oidc_backend.auth_callback_func.call_args[0]
-        self.assert_expected_attributes(internal_attributes, userinfo, args[1].attributes)
+        self.assert_expected_attributes(internal_attributes, userinfo, args[1]["attributes"])
 
 
 class TestCreateClient(object):

--- a/tests/satosa/backends/test_orcid.py
+++ b/tests/satosa/backends/test_orcid.py
@@ -178,9 +178,11 @@ class TestOrcidBackend(object):
     @responses.activate
     def test_authn_response(self, backend_config, userinfo, incoming_authn_response):
         self.setup_token_endpoint(
-            backend_config["server_info"]["token_endpoint"])
+            backend_config["server_info"]["token_endpoint"]
+        )
         self.setup_userinfo_endpoint(
-            backend_config["server_info"]["user_info"], userinfo)
+            backend_config["server_info"]["user_info"], userinfo
+        )
 
         self.orcid_backend._authn_response(incoming_authn_response)
 
@@ -188,7 +190,7 @@ class TestOrcidBackend(object):
         assert isinstance(args[0], Context)
         assert isinstance(args[1], InternalData)
 
-        self.assert_expected_attributes(userinfo, args[1].attributes)
+        self.assert_expected_attributes(userinfo, args[1]["attributes"])
 
     @responses.activate
     def test_user_information(self, context, backend_config, userinfo):

--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -61,11 +61,11 @@ def assert_redirect_to_idp(redirect_response, idp_conf):
 
 
 def assert_authn_response(internal_resp):
-    assert internal_resp.auth_info.auth_class_ref == PASSWORD
+    assert internal_resp["auth_info"]["auth_class_ref"] == PASSWORD
     expected_data = {'surname': ['Testsson 1'], 'mail': ['test@example.com'],
                      'displayname': ['Test Testsson'], 'givenname': ['Test 1'],
                      'edupersontargetedid': ['one!for!all']}
-    assert expected_data == internal_resp.attributes
+    assert expected_data == internal_resp["attributes"]
 
 
 def setup_test_config(sp_conf, idp_conf):
@@ -275,7 +275,7 @@ class TestSAMLBackend:
             samlbackend.authn_response(context, response_binding)
 
         context, internal_resp = samlbackend.auth_callback_func.call_args[0]
-        assert Counter(internal_resp.attributes.keys()) == Counter({"mail", "givenname", "displayname", "surname"})
+        assert Counter(internal_resp["attributes"].keys()) == Counter({"mail", "givenname", "displayname", "surname"})
 
     def test_backend_reads_encryption_key_from_key_file(self, sp_conf):
         sp_conf["key_file"] = os.path.join(TEST_RESOURCE_BASE_PATH, "encryption_key.pem")

--- a/tests/satosa/frontends/test_openid_connect.py
+++ b/tests/satosa/frontends/test_openid_connect.py
@@ -153,11 +153,13 @@ class TestOpenIDConnectFrontend(object):
         auth_info = AuthenticationInformation(
             PASSWORD, "2015-09-30T12:21:37Z", "unittest_idp.xml"
         )
-        internal_response = InternalData(auth_info=auth_info)
-        internal_response.attributes = AttributeMapper(
-            frontend.internal_attributes
-        ).to_internal("saml", USERS["testuser1"])
-        internal_response.subject_id = USERS["testuser1"]["eduPersonTargetedID"][0]
+        internal_response = InternalData(
+            auth_info=auth_info,
+            attributes=AttributeMapper(
+                frontend.internal_attributes
+            ).to_internal("saml", USERS["testuser1"]),
+            subject_id=USERS["testuser1"]["eduPersonTargetedID"][0],
+        )
 
         return internal_response
 
@@ -188,10 +190,10 @@ class TestOpenIDConnectFrontend(object):
 
         assert mock_callback.call_count == 1
         context, internal_req = mock_callback.call_args[0]
-        assert internal_req.requester == authn_req["client_id"]
-        assert internal_req.requester_name == [{"lang": "en", "text": client_name}]
-        assert internal_req.subject_type == 'pairwise'
-        assert internal_req.attributes == ["mail"]
+        assert internal_req["requester"] == authn_req["client_id"]
+        assert internal_req["requester_name"] == [{"lang": "en", "text": client_name}]
+        assert internal_req["subject_type"] == 'pairwise'
+        assert internal_req["attributes"] == ["mail"]
 
     def test_handle_authn_request_with_extra_scopes(
         self, context, frontend_with_extra_scopes, authn_req_with_extra_scopes
@@ -206,10 +208,10 @@ class TestOpenIDConnectFrontend(object):
         context.request = dict(parse_qsl(authn_req_with_extra_scopes.to_urlencoded()))
         frontend_with_extra_scopes.handle_authn_request(context)
         internal_req = frontend_with_extra_scopes._handle_authn_request(context)
-        assert internal_req.requester == authn_req_with_extra_scopes["client_id"]
-        assert internal_req.requester_name == [{"lang": "en", "text": client_name}]
-        assert internal_req.subject_type == "pairwise"
-        assert sorted(internal_req.attributes) == [
+        assert internal_req["requester"] == authn_req_with_extra_scopes["client_id"]
+        assert internal_req["requester_name"] == [{"lang": "en", "text": client_name}]
+        assert internal_req["subject_type"] == "pairwise"
+        assert sorted(internal_req["attributes"]) == [
             "eduPersonPrincipalName",
             "eduPersonScopedAffiliation",
             "mail",

--- a/tests/satosa/micro_services/test_attribute_authorization.py
+++ b/tests/satosa/micro_services/test_attribute_authorization.py
@@ -12,88 +12,76 @@ class TestAttributeAuthorization:
         return authz_service
 
     def test_authz_allow_success(self):
-        attribute_allow = {
-           "": { "default": {"a0": ['.+@.+']} }
-        }
+        attribute_allow = {"": {"default": {"a0": ['.+@.+']}}}
         attribute_deny = {}
         authz_service = self.create_authz_service(attribute_allow, attribute_deny)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a0": ["test@example.com"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={"a0": ["test@example.com"]},
+        )
         try:
-           ctx = Context()
-           ctx.state = dict()
-           authz_service.process(ctx, resp)
+            ctx = Context()
+            ctx.state = dict()
+            authz_service.process(ctx, resp)
         except SATOSAAuthenticationError as ex:
-           assert False
+            assert False
 
     def test_authz_allow_fail(self):
-        attribute_allow = {
-           "": { "default": {"a0": ['foo1','foo2']} }
-        }
+        attribute_allow = {"": {"default": {"a0": ['foo1', 'foo2']}}}
         attribute_deny = {}
         authz_service = self.create_authz_service(attribute_allow, attribute_deny)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a0": ["bar"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={"a0": ["bar"]},
+        )
         try:
-           ctx = Context()
-           ctx.state = dict()
-           authz_service.process(ctx, resp)
-           assert False
+            ctx = Context()
+            ctx.state = dict()
+            authz_service.process(ctx, resp)
+            assert False
         except SATOSAAuthenticationError as ex:
-           assert True
+            assert True
 
     def test_authz_allow_second(self):
-        attribute_allow = {
-           "": { "default": {"a0": ['foo1','foo2']} }
-        }
+        attribute_allow = {"": {"default": {"a0": ['foo1', 'foo2']}}}
         attribute_deny = {}
         authz_service = self.create_authz_service(attribute_allow, attribute_deny)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a0": ["foo2","kaka"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={"a0": ["foo2", "kaka"]},
+        )
         try:
-           ctx = Context()
-           ctx.state = dict()
-           authz_service.process(ctx, resp)
+            ctx = Context()
+            ctx.state = dict()
+            authz_service.process(ctx, resp)
         except SATOSAAuthenticationError as ex:
-           assert False
+            assert False
 
     def test_authz_deny_success(self):
-        attribute_deny = {
-           "": { "default": {"a0": ['foo1','foo2']} }
-        }
+        attribute_deny = {"": {"default": {"a0": ['foo1', 'foo2']}}}
         attribute_allow = {}
         authz_service = self.create_authz_service(attribute_allow, attribute_deny)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a0": ["foo2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(), attributes={"a0": ["foo2"]}
+        )
         try:
-           ctx = Context()
-           ctx.state = dict()
-           authz_service.process(ctx, resp)
-           assert False
+            ctx = Context()
+            ctx.state = dict()
+            authz_service.process(ctx, resp)
+            assert False
         except SATOSAAuthenticationError as ex:
-           assert True
+            assert True
 
     def test_authz_deny_fail(self):
-        attribute_deny = {
-           "": { "default": {"a0": ['foo1','foo2']} }
-        }
+        attribute_deny = {"": {"default": {"a0": ['foo1', 'foo2']}}}
         attribute_allow = {}
         authz_service = self.create_authz_service(attribute_allow, attribute_deny)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a0": ["foo3"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(), attributes={"a0": ["foo3"]}
+        )
         try:
-           ctx = Context()
-           ctx.state = dict()
-           authz_service.process(ctx, resp)
+            ctx = Context()
+            ctx.state = dict()
+            authz_service.process(ctx, resp)
         except SATOSAAuthenticationError as ex:
-           assert False
+            assert False

--- a/tests/satosa/micro_services/test_attribute_generation.py
+++ b/tests/satosa/micro_services/test_attribute_generation.py
@@ -17,49 +17,55 @@ class TestAddSyntheticAttributes:
            "": { "default": {"a0": "value1;value2" }}
         }
         authz_service = self.create_syn_service(synthetic_attributes)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a1": ["test@example.com"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={
+                "a1": ["test@example.com"],
+            },
+        )
         ctx = Context()
         ctx.state = dict()
         authz_service.process(ctx, resp)
-        assert("value1" in resp.attributes['a0'])
-        assert("value2" in resp.attributes['a0'])
-        assert("test@example.com" in resp.attributes['a1'])
+        assert("value1" in resp["attributes"]['a0'])
+        assert("value2" in resp["attributes"]['a0'])
+        assert("test@example.com" in resp["attributes"]['a1'])
 
     def test_generate_mustache1(self):
         synthetic_attributes = {
            "": { "default": {"a0": "{{kaka}}#{{eppn.scope}}" }}
         }
         authz_service = self.create_syn_service(synthetic_attributes)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "kaka": ["kaka1"],
-            "eppn": ["a@example.com","b@example.com"]
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={
+                "kaka": ["kaka1"],
+                "eppn": ["a@example.com","b@example.com"]
+            },
+        )
         ctx = Context()
         ctx.state = dict()
         authz_service.process(ctx, resp)
-        assert("kaka1#example.com" in resp.attributes['a0'])
-        assert("kaka1" in resp.attributes['kaka'])
-        assert("a@example.com" in resp.attributes['eppn'])
-        assert("b@example.com" in resp.attributes['eppn'])
+        assert("kaka1#example.com" in resp["attributes"]['a0'])
+        assert("kaka1" in resp["attributes"]['kaka'])
+        assert("a@example.com" in resp["attributes"]['eppn'])
+        assert("b@example.com" in resp["attributes"]['eppn'])
 
     def test_generate_mustache2(self):
         synthetic_attributes = {
            "": { "default": {"a0": "{{kaka.first}}#{{eppn.scope}}" }}
         }
         authz_service = self.create_syn_service(synthetic_attributes)
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "kaka": ["kaka1","kaka2"],
-            "eppn": ["a@example.com","b@example.com"]
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={
+                "kaka": ["kaka1","kaka2"],
+                "eppn": ["a@example.com","b@example.com"]
+            },
+        )
         ctx = Context()
         ctx.state = dict()
         authz_service.process(ctx, resp)
-        assert("kaka1#example.com" in resp.attributes['a0'])
-        assert("kaka1" in resp.attributes['kaka'])
-        assert("a@example.com" in resp.attributes['eppn'])
-        assert("b@example.com" in resp.attributes['eppn'])
+        assert("kaka1#example.com" in resp["attributes"]['a0'])
+        assert("kaka1" in resp["attributes"]['kaka'])
+        assert("a@example.com" in resp["attributes"]['eppn'])
+        assert("b@example.com" in resp["attributes"]['eppn'])

--- a/tests/satosa/micro_services/test_attribute_modifications.py
+++ b/tests/satosa/micro_services/test_attribute_modifications.py
@@ -20,14 +20,16 @@ class TestFilterAttributeValues:
         }
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a1": ["abc:xyz"],
-            "a2": ["foo:bar", "1:foo:bar:2"],
-            "a3": ["a:foo:bar:b"]
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={
+                "a1": ["abc:xyz"],
+                "a2": ["foo:bar", "1:foo:bar:2"],
+                "a3": ["a:foo:bar:b"]
+            },
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": [], "a2": ["foo:bar", "1:foo:bar:2"], "a3": ["a:foo:bar:b"]}
+        assert filtered["attributes"] == {"a1": [], "a2": ["foo:bar", "1:foo:bar:2"], "a3": ["a:foo:bar:b"]}
 
     def test_filter_one_attribute_from_all_target_providers_for_all_requesters(self):
         attribute_filters = {
@@ -39,64 +41,48 @@ class TestFilterAttributeValues:
         }
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(AuthenticationInformation())
-        resp.attributes = {
-            "a1": ["abc:xyz"],
-            "a2": ["foo:bar", "1:foo:bar:2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={"a1": ["abc:xyz"], "a2": ["foo:bar", "1:foo:bar:2"]},
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": ["abc:xyz"], "a2": ["foo:bar"]}
+        assert filtered["attributes"] == {"a1": ["abc:xyz"], "a2": ["foo:bar"]}
 
     def test_filter_one_attribute_from_all_target_providers_for_one_requester(self):
         requester = "test_requester"
-        attribute_filters = {
-            "": {
-                requester:
-                    {"a1": "foo:bar"}
-            }
-        }
+        attribute_filters = {"": {requester: {"a1": "foo:bar"}}}
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.requester = requester
-        resp.attributes = {
-            "a1": ["abc:xyz", "1:foo:bar:2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            requester=requester,
+            attributes={"a1": ["abc:xyz", "1:foo:bar:2"]},
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": ["1:foo:bar:2"]}
+        assert filtered["attributes"] == {"a1": ["1:foo:bar:2"]}
 
     def test_filter_attribute_not_in_response(self):
-        attribute_filters = {
-            "": {
-                "":
-                    {"a0": "foo:bar"}
-            }
-        }
+        attribute_filters = {"": {"": {"a0": "foo:bar"}}}
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(auth_info=AuthenticationInformation())
-        resp.attributes = {
-            "a1": ["abc:xyz", "1:foo:bar:2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(),
+            attributes={"a1": ["abc:xyz", "1:foo:bar:2"]},
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": ["abc:xyz", "1:foo:bar:2"]}
+        assert filtered["attributes"] == {"a1": ["abc:xyz", "1:foo:bar:2"]}
 
     def test_filter_one_attribute_for_one_target_provider(self):
         target_provider = "test_provider"
-        attribute_filters = {
-            target_provider: {
-                "":
-                    {"a1": "foo:bar"}
-            }
-        }
+        attribute_filters = {target_provider: {"": {"a1": "foo:bar"}}}
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(auth_info=AuthenticationInformation(issuer=target_provider))
-        resp.attributes = {
-            "a1": ["abc:xyz", "1:foo:bar:2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(issuer=target_provider),
+            attributes={"a1": ["abc:xyz", "1:foo:bar:2"]},
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": ["1:foo:bar:2"]}
+        assert filtered["attributes"] == {"a1": ["1:foo:bar:2"]}
 
     def test_filter_one_attribute_for_one_target_provider_for_one_requester(self):
         target_provider = "test_provider"
@@ -109,10 +95,10 @@ class TestFilterAttributeValues:
         }
         filter_service = self.create_filter_service(attribute_filters)
 
-        resp = InternalData(auth_info=AuthenticationInformation(issuer=target_provider))
-        resp.requester = requester
-        resp.attributes = {
-            "a1": ["abc:xyz", "1:foo:bar:2"],
-        }
+        resp = InternalData(
+            auth_info=AuthenticationInformation(issuer=target_provider),
+            requester=requester,
+            attributes={"a1": ["abc:xyz", "1:foo:bar:2"]},
+        )
         filtered = filter_service.process(None, resp)
-        assert filtered.attributes == {"a1": ["1:foo:bar:2"]}
+        assert filtered["attributes"] == {"a1": ["1:foo:bar:2"]}

--- a/tests/satosa/micro_services/test_custom_routing.py
+++ b/tests/satosa/micro_services/test_custom_routing.py
@@ -20,8 +20,11 @@ def target_context(context):
 
 class TestDecideIfRequesterIsAllowed:
     def create_decide_service(self, rules):
-        decide_service = DecideIfRequesterIsAllowed(config=dict(rules=rules), name="test_decide_service",
-                                                    base_url="https://satosa.example.com")
+        decide_service = DecideIfRequesterIsAllowed(
+            config=dict(rules=rules),
+            name="test_decide_service",
+            base_url="https://satosa.example.com",
+        )
         decide_service.next = lambda ctx, data: data
         return decide_service
 
@@ -36,7 +39,7 @@ class TestDecideIfRequesterIsAllowed:
         req = InternalData(requester="test_requester")
         assert decide_service.process(target_context, req)
 
-        req.requester = "somebody else"
+        req["requester"] = "somebody else"
         with pytest.raises(SATOSAError):
             decide_service.process(target_context, req)
 
@@ -97,7 +100,7 @@ class TestDecideIfRequesterIsAllowed:
 
         assert decide_service.process(target_context, req)
 
-        req.requester = "somebody else"
+        req["requester"] = "somebody else"
         with pytest.raises(SATOSAError):
             decide_service.process(target_context, req)
 

--- a/tests/satosa/test_base.py
+++ b/tests/satosa/test_base.py
@@ -45,16 +45,18 @@ class TestSATOSABase:
         satosa_config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"] = ["user_id", "domain"]
         base = SATOSABase(satosa_config)
 
-        internal_resp = InternalData(auth_info=AuthenticationInformation("", "", ""))
-        internal_resp.attributes = {"user_id": ["user"], "domain": ["@example.com"]}
-        internal_resp.requester = "test_requester"
+        internal_resp = InternalData(
+            auth_info=AuthenticationInformation("", "", ""),
+            attributes={"user_id": ["user"], "domain": ["@example.com"]},
+            requester="test_requester",
+        )
         context.state[satosa.base.STATE_KEY] = {"requester": "test_requester"}
         context.state[satosa.routing.STATE_KEY] = satosa_config["FRONTEND_MODULES"][0]["name"]
 
         base._auth_resp_callback_func(context, internal_resp)
 
         expected_user_id = "user@example.com"
-        assert internal_resp.subject_id == expected_user_id
+        assert internal_resp["subject_id"] == expected_user_id
 
     def test_auth_req_callback_stores_state_for_consent(self, context, satosa_config):
         base = SATOSABase(satosa_config)
@@ -62,28 +64,31 @@ class TestSATOSABase:
         context.target_backend = satosa_config["BACKEND_MODULES"][0]["name"]
         requester_name = [{"lang": "en", "text": "Test EN"}, {"lang": "sv", "text": "Test SV"}]
         internal_req = InternalData(
-            subject_type=NAMEID_FORMAT_TRANSIENT, requester_name=requester_name,
+            subject_type=NAMEID_FORMAT_TRANSIENT,
+            requester_name=requester_name,
+            attributes=["attr1", "attr2"],
         )
-        internal_req.attributes = ["attr1", "attr2"]
         base._auth_req_callback_func(context, internal_req)
 
-        assert context.state[consent.STATE_KEY]["requester_name"] == internal_req.requester_name
-        assert context.state[consent.STATE_KEY]["filter"] == internal_req.attributes
+        assert context.state[consent.STATE_KEY]["requester_name"] == internal_req["requester_name"]
+        assert context.state[consent.STATE_KEY]["filter"] == internal_req["attributes"]
 
     def test_auth_resp_callback_func_hashes_all_specified_attributes(self, context, satosa_config):
         satosa_config["INTERNAL_ATTRIBUTES"]["hash"] = ["user_id", "mail"]
         base = SATOSABase(satosa_config)
 
         attributes = {"user_id": ["user"], "mail": ["user@example.com", "user@otherdomain.com"]}
-        internal_resp = InternalData(auth_info=AuthenticationInformation("", "", ""))
-        internal_resp.attributes = copy.copy(attributes)
-        internal_resp.subject_id = "test_user"
+        internal_resp = InternalData(
+            auth_info=AuthenticationInformation("", "", ""),
+            attributes=copy.copy(attributes),
+            subject_id="test_user",
+        )
         context.state[satosa.base.STATE_KEY] = {"requester": "test_requester"}
         context.state[satosa.routing.STATE_KEY] = satosa_config["FRONTEND_MODULES"][0]["name"]
 
         base._auth_resp_callback_func(context, internal_resp)
         for attr in satosa_config["INTERNAL_ATTRIBUTES"]["hash"]:
-            assert internal_resp.attributes[attr] == [
+            assert internal_resp["attributes"][attr] == [
                 util.hash_data(satosa_config.get("USER_ID_HASH_SALT", ""), v)
                 for v in attributes[attr]
             ]
@@ -92,13 +97,15 @@ class TestSATOSABase:
         satosa_config["INTERNAL_ATTRIBUTES"]["user_id_to_attr"] = "user_id"
         base = SATOSABase(satosa_config)
 
-        internal_resp = InternalData(auth_info=AuthenticationInformation("", "", ""))
-        internal_resp.subject_id = "user1234"
+        internal_resp = InternalData(
+            auth_info=AuthenticationInformation("", "", ""),
+            subject_id="user1234",
+        )
         context.state[satosa.base.STATE_KEY] = {"requester": "test_requester"}
         context.state[satosa.routing.STATE_KEY] = satosa_config["FRONTEND_MODULES"][0]["name"]
 
         base._auth_resp_callback_func(context, internal_resp)
-        assert internal_resp.attributes["user_id"] == [internal_resp.subject_id]
+        assert internal_resp["attributes"]["user_id"] == [internal_resp["subject_id"]]
 
     @pytest.mark.parametrize("micro_services", [
         [Mock()],

--- a/tests/util.py
+++ b/tests/util.py
@@ -469,9 +469,11 @@ class TestBackend(BackendModule):
 
     def handle_response(self, context):
         auth_info = AuthenticationInformation("test", str(datetime.now()), "test_issuer")
-        internal_resp = InternalData(auth_info=auth_info)
-        internal_resp.attributes = context.request
-        internal_resp.subject_id = "test_user"
+        internal_resp = InternalData(
+            auth_info=auth_info,
+            attributes=context.request,
+            subject_id="test_user",
+        )
         return self.auth_callback_func(context, internal_resp)
 
 


### PR DESCRIPTION
The internal objects now have a dict-like interface. By deprecating the attribute-interface we make sure that these objects are treated like dictionaries.

---

Continuation of https://github.com/IdentityPython/SATOSA/pull/299

---

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?