### PR TITLE
Use Ubuntu 18.04 for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \


### PR DESCRIPTION
- Bumps ubuntu version to 18.04 for the docker image. This version uses
python 3.6 which is now our lowest python version supported
- Fixes #310

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


