### PR TITLE
Better handling of single-value attribute by LdapAttributeStore

### DIFF
--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -12,8 +12,6 @@ import urllib
 import ldap3
 from ldap3.core.exceptions import LDAPException
 
-from collections import defaultdict
-
 from satosa.exception import SATOSAError
 from satosa.logging_util import satosa_logging
 from satosa.micro_services.base import ResponseMicroService
@@ -350,7 +348,7 @@ class LdapAttributeStore(ResponseMicroService):
             else config["search_return_attributes"]
         )
 
-        attributes = defaultdict(list)
+        attributes = {}
 
         for attr, values in ldap_attributes.items():
             internal_attr = ldap_to_internal_map.get(attr, None)
@@ -358,7 +356,11 @@ class LdapAttributeStore(ResponseMicroService):
                 internal_attr = ldap_to_internal_map.get(attr.split(";")[0], None)
 
             if internal_attr and values:
-                attributes[internal_attr].extend(values)
+                attributes[internal_attr] = (
+                    values
+                    if isinstance(values, list)
+                    else [values]
+                )
                 msg = "Recording internal attribute {} with values {}"
                 msg = msg.format(internal_attr, attributes[internal_attr])
                 satosa_logging(logger, logging.DEBUG, msg, None)

--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -293,6 +293,7 @@ class LdapAttributeStore(ResponseMicroService):
             "LDIF": ldap3.LDIF,
             "RESTARTABLE": ldap3.RESTARTABLE,
             "REUSABLE": ldap3.REUSABLE,
+            "MOCK_SYNC": ldap3.MOCK_SYNC
         }
         client_strategy = client_strategy_map[client_strategy_string]
 
@@ -503,7 +504,7 @@ class LdapAttributeStore(ResponseMicroService):
         # This adapts records with different search and connection strategy
         # (sync without pool), it should be tested with anonimous bind with
         # message_id.
-        if isinstance(results, bool):
+        if isinstance(results, bool) and record:
             record = {
                 "dn": record.entry_dn if hasattr(record, "entry_dn") else "",
                 "attributes": (

--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -263,7 +263,22 @@ class LdapAttributeStore(ResponseMicroService):
         if not bind_password:
             raise LdapAttributeStoreError("bind_password is not configured")
 
-        server = ldap3.Server(config["ldap_url"])
+        client_strategy_string = config["client_strategy"]
+        client_strategy_map = {
+            "SYNC": ldap3.SYNC,
+            "ASYNC": ldap3.ASYNC,
+            "LDIF": ldap3.LDIF,
+            "RESTARTABLE": ldap3.RESTARTABLE,
+            "REUSABLE": ldap3.REUSABLE,
+            "MOCK_SYNC": ldap3.MOCK_SYNC
+        }
+        client_strategy = client_strategy_map[client_strategy_string]
+
+        args = {'host': config["ldap_url"]}
+        if client_strategy == ldap3.MOCK_SYNC:
+            args['get_info'] = ldap3.OFFLINE_SLAPD_2_4
+
+        server = ldap3.Server(**args)
 
         msg = "Creating a new LDAP connection"
         satosa_logging(logger, logging.DEBUG, msg, None)
@@ -285,17 +300,6 @@ class LdapAttributeStore(ResponseMicroService):
 
         read_only = config["read_only"]
         version = config["version"]
-
-        client_strategy_string = config["client_strategy"]
-        client_strategy_map = {
-            "SYNC": ldap3.SYNC,
-            "ASYNC": ldap3.ASYNC,
-            "LDIF": ldap3.LDIF,
-            "RESTARTABLE": ldap3.RESTARTABLE,
-            "REUSABLE": ldap3.REUSABLE,
-            "MOCK_SYNC": ldap3.MOCK_SYNC
-        }
-        client_strategy = client_strategy_map[client_strategy_string]
 
         pool_size = config["pool_size"]
         pool_keepalive = config["pool_keepalive"]

--- a/tests/satosa/micro_services/test_ldap_attribute_store.py
+++ b/tests/satosa/micro_services/test_ldap_attribute_store.py
@@ -7,6 +7,8 @@ from satosa.internal import InternalData
 from satosa.micro_services.ldap_attribute_store import LdapAttributeStore
 from satosa.context import Context
 
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 class TestLdapAttributeStore:
     ldap_attribute_store_config = {
@@ -21,15 +23,13 @@ class TestLdapAttributeStore:
                 'givenName',
                 'sn',
                 'mail',
-                'employeeNumber',
-                'voPersonID'
+                'employeeNumber'
             ],
             'ldap_to_internal_map': {
                 'givenName': 'givenname',
                 'sn': 'sn',
                 'mail': 'mail',
-                'employeeNumber': 'employeenumber',
-                'voPersonID': 'vopersonid'
+                'employeeNumber': 'employeenumber'
             },
             'clear_input_attributes': True,
             'ordered_identifier_candidates': [
@@ -46,8 +46,7 @@ class TestLdapAttributeStore:
             'givenName': 'Jane',
             'sn': 'Baxter',
             'uid': 'jbaxter',
-            'mail': 'jbaxter@example.com',
-            'voPersonID': 'EX1000'
+            'mail': 'jbaxter@example.com'
             }
          ],
         ['employeeNumber=1001,ou=people,dc=example,dc=com', {
@@ -56,8 +55,7 @@ class TestLdapAttributeStore:
             'givenName': 'Booker',
             'sn': 'Lawson',
             'uid': 'booker.lawson',
-            'mail': 'blawson@example.com',
-            'voPersonID': 'EX1001'
+            'mail': 'blawson@example.com'
             }
          ],
     ]

--- a/tests/satosa/micro_services/test_ldap_attribute_store.py
+++ b/tests/satosa/micro_services/test_ldap_attribute_store.py
@@ -1,0 +1,111 @@
+import pytest
+
+from copy import deepcopy
+
+from satosa.internal import AuthenticationInformation
+from satosa.internal import InternalData
+from satosa.micro_services.ldap_attribute_store import LdapAttributeStore
+from satosa.context import Context
+
+
+class TestLdapAttributeStore:
+    ldap_attribute_store_config = {
+        'default': {
+            'auto_bind': 'AUTO_BIND_NO_TLS',
+            'client_strategy': 'MOCK_SYNC',
+            'ldap_url': 'ldap://satosa.example.com',
+            'bind_dn': 'uid=readonly_user,ou=system,dc=example,dc=com',
+            'bind_password': 'password',
+            'search_base': 'ou=people,dc=example,dc=com',
+            'query_return_attributes': [
+                'givenName',
+                'sn',
+                'mail',
+                'employeeNumber',
+                'voPersonID'
+            ],
+            'ldap_to_internal_map': {
+                'givenName': 'givenname',
+                'sn': 'sn',
+                'mail': 'mail',
+                'employeeNumber': 'employeenumber',
+                'voPersonID': 'vopersonid'
+            },
+            'clear_input_attributes': True,
+            'ordered_identifier_candidates': [
+                {'attribute_names': ['uid']}
+            ],
+            'ldap_identifier_attribute': 'uid'
+        }
+    }
+
+    ldap_person_records = [
+        ['employeeNumber=1000,ou=people,dc=example,dc=com', {
+            'employeeNumber': '1000',
+            'cn': 'Jane Baxter',
+            'givenName': 'Jane',
+            'sn': 'Baxter',
+            'uid': 'jbaxter',
+            'mail': 'jbaxter@example.com',
+            'voPersonID': 'EX1000'
+            }
+         ],
+        ['employeeNumber=1001,ou=people,dc=example,dc=com', {
+            'employeeNumber': '1001',
+            'cn': 'Booker Lawson',
+            'givenName': 'Booker',
+            'sn': 'Lawson',
+            'uid': 'booker.lawson',
+            'mail': 'blawson@example.com',
+            'voPersonID': 'EX1001'
+            }
+         ],
+    ]
+
+    @pytest.fixture
+    def ldap_attribute_store(self):
+        store = LdapAttributeStore(self.ldap_attribute_store_config,
+                                   name="test_ldap_attribute_store",
+                                   base_url="https://satosa.example.com")
+
+        # Mock up the 'next' microservice to be called.
+        store.next = lambda ctx, data: data
+
+        # We need to explicitly bind when using the MOCK_SYNC client strategy.
+        connection = store.config['default']['connection']
+        connection.bind()
+
+        # Populate example records.
+        for dn, attributes in self.ldap_person_records:
+            attributes = deepcopy(attributes)
+            connection.strategy.add_entry(dn, attributes)
+
+        return store
+
+    def test_attributes_general(self, ldap_attribute_store):
+        ldap_to_internal_map = (self.ldap_attribute_store_config['default']
+                                ['ldap_to_internal_map'])
+
+        for dn, attributes in self.ldap_person_records:
+            # Mock up the internal response the LDAP attribute store is
+            # expecting to receive.
+            response = InternalData(auth_info=AuthenticationInformation())
+
+            # The LDAP attribute store configuration and the mock records
+            # expect to use a LDAP search filter for the uid attribute.
+            uid = attributes['uid']
+            response.attributes = {'uid': uid}
+
+            context = Context()
+            context.state = dict()
+
+            ldap_attribute_store.process(context, response)
+
+            # Verify that the LDAP attribute store has retrieved the mock
+            # records from the mock LDAP server and has added the appropriate
+            # internal attributes.
+            for ldap_attr, ldap_value in attributes.items():
+                if ldap_attr in ldap_to_internal_map:
+                    internal_attr = ldap_to_internal_map[ldap_attr]
+                    response_attr = response.attributes[internal_attr]
+                    assert(ldap_value in response_attr)

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 responses
 beautifulsoup4
+ldap3


### PR DESCRIPTION
Better handling of single-value attributes from LDAP by the
LdapAttributeStore microservice. The ldap3 module response object
includes a raw_attributes dictionary and an attributes dictionary. The
attributes dictionary is populated with formatted values using
formatters based on standard schema syntaxes. If a particular attribute
in the schema is defined as multi valued, the attribute value in the
attributes dictionary is a list, but if the attribute in the schema is
not multi valued, the value in the attributes dictionary is a single
value.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?