### PR TITLE
Config to disable discovery initiated SAMLBackend flows

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -59,3 +59,8 @@ config:
         name_id_format_allow_create: true
   # disco_srv must be defined if there is more than one IdP in the metadata specified above
   disco_srv: http://disco.example.com
+
+  # Allow flows to start at the discovery response endpoint.
+  # Not recommend but allowed by default for backwards compatiblity.
+  # Default will change to false in a later release.
+  # allow_discovery_initiated: true


### PR DESCRIPTION
The current SAMLBackend allows a flow to start with the
disco_response() endpoint, i.e., a client passing in the
entityID of the IdP to be used for authentication. In most
deployments the flow will fail after the backend receives the
SAMLResponse, parses it, and passes control to the frontend
since the frontend does not know to which relying party to redirect the
browser. But it is possible for some deployments to make a flow that
starts with the disco_response() work so just preventing such flows is
not acceptable. This commit enables configuring the SAMLBackend so that
flows are not allowed to be started at disco_response(), and when so
configured a flow that starts at disco_response() will raise an
exception with a useful message rather than continuing on to
a frontend and failing with UnknownError.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [X ] Have you written new tests for your changes?
* [ X] Does your submission pass tests?
* [X ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


