### PR TITLE
Redirect Page on "Unknown Errors" exception

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -311,7 +311,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :param binding: The saml binding type
         :return: response
         """
-        if not context.request["SAMLResponse"]:
+        if not context.request.get("SAMLResponse"):
             msg = "Missing Response for state"
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.debug(logline)

--- a/src/satosa/exception.py
+++ b/src/satosa/exception.py
@@ -38,6 +38,20 @@ class SATOSAUnknownError(SATOSAError):
     pass
 
 
+class SATOSABackendNotFoundError(SATOSAError):
+    """
+    SATOSA Backend not existent/not found
+    """
+    pass
+
+
+class SATOSAUnknownErrorRedirectUrl(SATOSAError):
+    """
+    SATOSA unknown error redirect page
+    """
+    pass
+
+
 class SATOSAAuthenticationError(SATOSAError):
     """
     SATOSA authentication error.

--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -11,7 +11,8 @@ import satosa
 import satosa.logging_util as lu
 from .base import SATOSABase
 from .context import Context
-from .response import ServiceError, NotFound
+from .exception import SATOSAUnknownErrorRedirectUrl
+from .response import ServiceError, NotFound, Redirect
 from .routing import SATOSANoBoundEndpointError
 from saml2.s_utils import UnknownSystemEntity
 
@@ -125,6 +126,9 @@ class WsgiApplication(SATOSABase):
             logger.debug(logline)
             resp = NotFound("The Service or Identity Provider you requested could not be found.")
             return resp(environ, start_response)
+        except SATOSAUnknownErrorRedirectUrl as e:
+            redirect_url, error_log = json.loads(str(e))
+            return Redirect(redirect_url)(environ, start_response)
         except Exception as e:
             if type(e) != UnknownSystemEntity:
                 logline = "{}".format(e)


### PR DESCRIPTION
This PR introduces a new `proxy_config.yml` parameter called `UNKNOW_ERROR_REDIRECT_PAGE`, a possibility to redirect to that page all the Users that gets UnknowError Exception as Http Response.

- Added a `UnknownSystemEntity` message for humans in `satosa.base` (Why don't we use a settings_messages.py file and import them all from there?)
- Added `exceptions.SATOSAUnknownErrorRedirectUrl`
- Also fixed a unhandled Exception here: https://github.com/IdentityPython/SATOSA/pull/323/files#diff-7096df3e286d488b77d9e6f1ff6622c6

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


