### PR TITLE
Context state keyError Exception message for humans

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -134,6 +134,12 @@ class SATOSABase(object):
         """
 
         context.request = None
+        context_state = context.state.get(STATE_KEY)
+        if not context_state:
+            redirect_url = self.config.get("UNKNOW_ERROR_REDIRECT_PAGE")
+            raise SATOSAStateError(('context.state has no {}. Your session '
+                                    'is not valid, please start a new '
+                                    'Authentication request again.'.format(STATE_KEY)))
         internal_response.requester = context.state[STATE_KEY]["requester"]
 
         # If configured construct the user id from attribute values.


### PR DESCRIPTION
This PR introduces a human readable message to Users when they gets SATOSA_BASE KeyError.
Found it usefull to avoid weird Users open assistane tickets when they gets that "ermetic" error on the screen.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


