### PR TITLE
HTTP Redirect page on UnknowError Exception

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -10,7 +10,7 @@ from saml2.s_utils import UnknownSystemEntity
 from satosa import util
 from .context import Context
 from .exception import SATOSAConfigurationError
-from .exception import SATOSAError, SATOSAAuthenticationError, SATOSAUnknownError
+from .exception import SATOSAError, SATOSAAuthenticationError, SATOSAUnknownError, SATOSAUnknownErrorRedirectUrl
 from .plugin_loader import load_backends, load_frontends
 from .plugin_loader import load_request_microservices, load_response_microservices
 from .routing import ModuleRouter, SATOSANoBoundEndpointError
@@ -250,12 +250,21 @@ class SATOSABase(object):
             msg = "configuration error: unknown system entity " + str(err)
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.error(logline, exc_info=False)
-            raise
+            raise UnknownSystemEntity(("Unknown System Entity ID - please check "
+                                       "requester entity ID, "
+                                       "AssertionConsumerService definitions "
+                                       "and other possible mismatches between "
+                                       "Service Provider Metadata and its AuthnRequest."))
         except Exception as err:
             msg = "Uncaught exception"
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.error(logline, exc_info=True)
-            raise SATOSAUnknownError("Unknown error") from err
+            redirect_url = self.config.get("UNKNOW_ERROR_REDIRECT_PAGE")
+            if redirect_url:
+                raise SATOSAUnknownErrorRedirectUrl((redirect_url, logline))
+            else:
+                raise SATOSAUnknownError("Unknown error") from err
+             
         return resp
 
 

--- a/src/satosa/exception.py
+++ b/src/satosa/exception.py
@@ -38,6 +38,13 @@ class SATOSAUnknownError(SATOSAError):
     pass
 
 
+class SATOSAUnknownErrorRedirectUrl(SATOSAError):
+    """
+    SATOSA unknown error redirect page
+    """
+    pass
+
+
 class SATOSAAuthenticationError(SATOSAError):
     """
     SATOSA authentication error.

--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -11,7 +11,8 @@ import satosa
 import satosa.logging_util as lu
 from .base import SATOSABase
 from .context import Context
-from .response import ServiceError, NotFound
+from .exception import SATOSAUnknownErrorRedirectUrl
+from .response import ServiceError, NotFound, Redirect
 from .routing import SATOSANoBoundEndpointError
 from saml2.s_utils import UnknownSystemEntity
 
@@ -125,13 +126,16 @@ class WsgiApplication(SATOSABase):
             logger.debug(logline)
             resp = NotFound("The Service or Identity Provider you requested could not be found.")
             return resp(environ, start_response)
+        except SATOSAUnknownErrorRedirectUrl as e:
+            redirect_url, error_log = e.args[0][0], e.args[0][1]
+            logger.debug('{}: Redirecting to "{}"'.format(error_log, redirect_url))
+            return Redirect(redirect_url)(environ, start_response)
         except Exception as e:
             if type(e) != UnknownSystemEntity:
                 logline = "{}".format(e)
                 logger.exception(logline)
             if debug:
                 raise
-
             resp = ServiceError("%s" % e)
             return resp(environ, start_response)
 


### PR DESCRIPTION
This PR introduces a new proxy_config.yml parameter called UNKNOW_ERROR_REDIRECT_PAGE, a possibility to redirect to that page all the Users that gets UnknowError Exception in the Http Response.

- Added a UnknownSystemEntity message for humans in satosa.base (We should also use a settings_messages.py file and import them all from there if you agree)
- Added exceptions.SATOSAUnknownErrorRedirectUrl

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


