### PR TITLE
AuthnContextClassRef in context.state

### DIFF
--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -189,6 +189,10 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         req_info = idp.parse_authn_request(context.request["SAMLRequest"], binding_in)
         authn_req = req_info.message
         msg = "{}".format(authn_req)
+        if "AuthnContextClassRef" in msg:
+            authn_context = msg[msg.find("<ns1:AuthnContextClassRef>") +
+                                26:msg.find("</ns1:AuthnContextClassRef>")]
+            context.state['authn_context_class_ref'] = authn_context
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
 


### PR DESCRIPTION
* adding AuthnContextClassRef to the context.state in order to make it available to microservices (specifically for the WebAuthn microservice)

* The reason why I needed this change is that the microservice has to decide whether to trigger the MFA or not

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


