### PR TITLE
Add sub_hash_salt to README and example configuration

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -433,6 +433,7 @@ The configuration parameters available:
 * `signing_key_path`: path to a RSA Private Key file (PKCS#1). MUST be configured.
 * `db_uri`: connection URI to MongoDB instance where the data will be persisted, if it's not specified all data will only
    be stored in-memory (not suitable for production use).
+* `sub_hash_salt`: salt which is hashed into the `sub` claim. If it's not specified, SATOSA will generate a random salt on each startup, which means that users will get new `sub` value after every restart.
 * `provider`: provider configuration information. MUST be configured, the following configuration are supported:
     * `response_types_supported` (default: `[id_token]`): list of all supported response types, see [Section 3 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).
     * `subject_types_supported` (default: `[pairwise]`): list of all supported subject identifier types, see [Section 8 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes)

--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -4,6 +4,7 @@ config:
   signing_key_path: frontend.key
   db_uri: mongodb://db.example.com # optional: only support MongoDB, will default to in-memory storage if not specified
   client_db_path: /path/to/your/cdb.json
+  sub_hash_salt: randomSALTvalue # if not specified, it is randomly generated on every startup
   provider:
     client_registration_supported: Yes
     response_types_supported: ["code", "id_token token"]


### PR DESCRIPTION
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
Missing documentation.
Note that `sub_hash_salt` is regenerated on startup if not specified in config, which results in varying identifiers.
https://github.com/IdentityPython/SATOSA/blob/8b641cebbc4910ecc5ac897a67e1e530cf408c24/src/satosa/frontends/openid_connect.py#L99
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
Not needed.
* [x] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
Not needed.

