### PR TITLE
Make the ScopeExtractorProcessor usable for the Primary Identifier

### DIFF
--- a/src/satosa/micro_services/processors/scope_extractor_processor.py
+++ b/src/satosa/micro_services/processors/scope_extractor_processor.py
@@ -31,6 +31,8 @@ class ScopeExtractorProcessor(BaseProcessor):
         values = attributes.get(attribute, [])
         if not values:
             raise AttributeProcessorWarning("Cannot apply scope_extractor to {}, it has no values".format(attribute))
+        if not isinstance(values, list):
+            values = [values]
         if not any('@' in val for val in values):
             raise AttributeProcessorWarning("Cannot apply scope_extractor to {}, it's values are not scoped".format(attribute))
         for value in values:


### PR DESCRIPTION
This patch adds support to use the ScopeExtractorProcessor on the Primary
Identifiert which is, in contrast to the other values, a string.

Closes #348

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


