### PR TITLE
New Microservice `AttributePolicy`

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -566,6 +566,18 @@ the string `"foo:bar"`:
         "attr1": "foo:bar"
 ```
 
+#### Apply a Attribute Policy
+
+Attributes delivered from the target provider can be filtered based on a list of allowed attributes per requester
+using the `AttributePolicy` class:
+```yaml
+attribute_policy:
+    <requester>:
+        allowed:
+            - attr1
+            - attr2
+```
+
 #### Route to a specific backend based on the requester
 To choose which backend (essentially choosing target provider) to use based on the requester, use the
 `DecideBackendByRequester` class which implements that special routing behavior. See the

--- a/src/satosa/micro_services/attribute_policy.py
+++ b/src/satosa/micro_services/attribute_policy.py
@@ -1,0 +1,35 @@
+import logging
+
+import satosa.logging_util as lu
+
+from .base import ResponseMicroService
+
+logger = logging.getLogger(__name__)
+
+
+class AttributePolicy(ResponseMicroService):
+    """
+    Module to filter Attributes by a given Policy.
+    """
+
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attribute_policy = config["attribute_policy"]
+
+    def process(self, context, data):
+        state = context.state
+        session_id = lu.get_session_id(state)
+
+        msg = "Incoming data.attributes {}".format(data.attributes)
+        logline = lu.LOG_FMT.format(id=session_id, message=msg)
+        logger.debug(logline)
+
+        policy = self.attribute_policy.get(data.requester, {})
+        if "allowed" in policy:
+            for key in (data.attributes.keys() - set(policy["allowed"])):
+                del data.attributes[key]
+
+        msg = "Returning data.attributes {}".format(data.attributes)
+        logline = lu.LOG_FMT.format(id=session_id, message=msg)
+        logger.debug(logline)
+        return super().process(context, data)

--- a/tests/satosa/micro_services/test_attribute_policy.py
+++ b/tests/satosa/micro_services/test_attribute_policy.py
@@ -1,0 +1,58 @@
+from satosa.context import Context
+from satosa.internal import AuthenticationInformation, InternalData
+from satosa.micro_services.attribute_policy import AttributePolicy
+
+
+class TestAttributePolicy:
+    def create_attribute_policy_service(self, attribute_policies):
+        attribute_policy_service = AttributePolicy(
+            config=attribute_policies,
+            name="test_attribute_policy",
+            base_url="https://satosa.example.com"
+        )
+        attribute_policy_service.next = lambda ctx, data: data
+        return attribute_policy_service
+
+    def test_attribute_policy(self):
+        requester = "requester"
+        attribute_policies = {
+            "attribute_policy": {
+                "requester_everything_allowed": {},
+                "requester_nothing_allowed": {
+                    "allowed": {}
+                },
+                "requester_subset_allowed": {
+                    "allowed": {
+                        "attr1",
+                        "attr2",
+                    },
+                },
+            },
+        }
+        attributes = {
+            "attr1": ["foo"],
+            "attr2": ["foo", "bar"],
+            "attr3": ["foo"]
+        }
+        results = {
+            "requester_everything_allowed": attributes.keys(),
+            "requester_nothing_allowed": set(),
+            "requester_subset_allowed": {"attr1", "attr2"},
+        }
+        for requester, result in results.items():
+            attribute_policy_service = self.create_attribute_policy_service(
+                attribute_policies)
+
+            ctx = Context()
+            ctx.state = dict()
+
+            resp = InternalData(auth_info=AuthenticationInformation())
+            resp.requester = requester
+            resp.attributes = {
+                "attr1": ["foo"],
+                "attr2": ["foo", "bar"],
+                "attr3": ["foo"]
+            }
+
+            filtered = attribute_policy_service.process(ctx, resp)
+            assert(filtered.attributes.keys() == result)


### PR DESCRIPTION
This patch introduces a new micro_service, which is able to force attribute
policies for requester by limiting results to a predefined set of allowed
attributes.

Sometimes you want to make sure that only specific attributes can be received by a specific requester.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


