### PR TITLE
Make the ID token lifetime configurable

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -442,7 +442,7 @@ The configuration parameters available:
     * `access_token_lifetime`: how long access tokens should be valid, see [default](https://github.com/SUNET/pyop#token-lifetimes)
     * `refresh_token_lifetime`: how long refresh tokens should be valid, if not specified no refresh tokens will be issued (which is [default](https://github.com/SUNET/pyop#token-lifetimes))
     * `refresh_token_threshold`: how long before expiration refresh tokens should be refreshed, if not specified refresh tokens will never be refreshed (which is [default](https://github.com/SUNET/pyop#token-lifetimes))
-    * `id_token_lifetime`: the lifetime of the ID token in seconds, see [default](https://github.com/SUNET/pyop#token-lifetimes)
+    * `id_token_lifetime`: the lifetime of the ID token in seconds - the default is set to 1hr (3600 seconds) (see [default](https://github.com/SUNET/pyop#token-lifetimes))
 
 The other parameters should be left with their default values.
 
@@ -692,5 +692,4 @@ set SATOSA_CONFIG=/home/user/proxy_conf.yaml
 ## Using Apache HTTP Server and mod\_wsgi
 
 See the [auxiliary documentation for running using mod\_wsgi](mod_wsgi.md).
-
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -442,6 +442,7 @@ The configuration parameters available:
     * `access_token_lifetime`: how long access tokens should be valid, see [default](https://github.com/SUNET/pyop#token-lifetimes)
     * `refresh_token_lifetime`: how long refresh tokens should be valid, if not specified no refresh tokens will be issued (which is [default](https://github.com/SUNET/pyop#token-lifetimes))
     * `refresh_token_threshold`: how long before expiration refresh tokens should be refreshed, if not specified refresh tokens will never be refreshed (which is [default](https://github.com/SUNET/pyop#token-lifetimes))
+    * `id_token_lifetime`: the lifetime of the ID token in seconds, see [default](https://github.com/SUNET/pyop#token-lifetimes)
 
 The other parameters should be left with their default values.
 

--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -14,4 +14,4 @@ config:
       foo_scope:
       - bar_claim
       - baz_claim
-    id_token_lifetime: 600
+    id_token_lifetime: 3600

--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -12,5 +12,6 @@ config:
     scopes_supported: ["openid", "email"]
     extra_scopes:
       foo_scope:
-	  - bar_claim
-	  - baz_claim
+      - bar_claim
+      - baz_claim
+    id_token_lifetime: 600

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -93,7 +93,7 @@ class OpenIDConnectFrontend(FrontendModule):
             cdb,
             Userinfo(self.user_db),
             extra_scopes=extra_scopes,
-            id_token_lifetime=self.config["provider"].get("id_token_lifetime", 600),
+            id_token_lifetime=self.config["provider"].get("id_token_lifetime", 3600),
         )
 
     def _init_authorization_state(self):

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -93,6 +93,7 @@ class OpenIDConnectFrontend(FrontendModule):
             cdb,
             Userinfo(self.user_db),
             extra_scopes=extra_scopes,
+            id_token_lifetime=self.config["provider"].get("id_token_lifetime", 600),
         )
 
     def _init_authorization_state(self):


### PR DESCRIPTION
This patch adds a new configuration option to the pyop Provider making it
possible to configure the lifetime of the ID token.

Sometime you need to configure the lifetime of the ID token. E.g. we are using the `JWT` for our web proxy and we need them to be valid as long as our session last.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests? **I did not test the mongodb stuff**
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


