### PR TITLE
Separate client db configuration from user-data db configuration

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -430,6 +430,8 @@ The configuration parameters available:
 * `signing_key_path`: path to a RSA Private Key file (PKCS#1). MUST be configured.
 * `db_uri`: connection URI to MongoDB instance where the data will be persisted, if it's not specified all data will only
    be stored in-memory (not suitable for production use).
+* `client_db_uri`: connection URI to MongoDB instance where the client data will be persistent, if it's not specified the clients list will be received from the `client_db_path`.
+* `client_db_path`: path to a file containing the client database in json format. It will only be used if `client_db_uri` is not set. If `client_db_uri` and `client_db_path` are not set, clients will only be stored in-memory (not suitable for production use).
 * `sub_hash_salt`: salt which is hashed into the `sub` claim. If it's not specified, SATOSA will generate a random salt on each startup, which means that users will get new `sub` value after every restart.
 * `provider`: provider configuration information. MUST be configured, the following configuration are supported:
     * `response_types_supported` (default: `[id_token]`): list of all supported response types, see [Section 3 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -77,9 +77,10 @@ class OpenIDConnectFrontend(FrontendModule):
 
         authz_state = self._init_authorization_state()
         db_uri = self.config.get("db_uri")
+        client_db_uri = self.config.get("client_db_uri")
         cdb_file = self.config.get("client_db_path")
-        if db_uri:
-            cdb = MongoWrapper(db_uri, "satosa", "clients")
+        if client_db_uri:
+            cdb = MongoWrapper(client_db_uri, "satosa", "clients")
         elif cdb_file:
             with open(cdb_file) as f:
                 cdb = json.loads(f.read())


### PR DESCRIPTION
This patch adds a new option `prefer_client_db_file` to provide the possibility
to prefer the file over the MongoDB for the client database.

We are deploying Satosa in Kubernetes and it's easier to provide the client database via a file. It enables us to do GitOps and have the configuration handled by git.

The new configuration defaults to `false`, so if not explicitly set, nothing changes here.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


