### PR TITLE
Option to add per client extra claims to ID Token

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -15,3 +15,7 @@ config:
       - bar_claim
       - baz_claim
     id_token_lifetime: 3600
+    extra_id_token_claims:
+      foo_client:
+        - bar_claim
+        - baz_claim


### PR DESCRIPTION
Some OIDC clients expect extra claims in the ID Token without explicitly asking
for them using the `claims` url parameter.
This patch adds an option to define in the config per client which extra claims
should be added to the ID Token to also work with those clients.

Co-authored-by: <blankburian@wwu.de>

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


