### PR TITLE
Add flake8 Config in Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,6 @@ commands =
   pip --version
   pip freeze
   pytest -vvv -ra {posargs:tests/}
+
+[flake8]
+ignore = E501


### PR DESCRIPTION
This patch adds a config section for flake8 to tox and also add an ignore for
long lines, since it seems like these errors are already actively ignored.

Some IDEs (tested only vscode) will pick this up and make working a lot easier
and clearer.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


