### PR TITLE
Remove some deprecated mongod flags

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,10 +396,9 @@ class MongoTemporaryInstance(object):
         self._process = subprocess.Popen(['mongod', '--bind_ip', 'localhost',
                                           '--port', str(self._port),
                                           '--dbpath', self._tmpdir,
-                                          '--nojournal', '--nohttpinterface',
-                                          '--noauth', '--smallfiles',
-                                          '--syncdelay', '0',
-                                          '--nssize', '1', ],
+                                          '--nojournal',
+                                          '--noauth',
+                                          '--syncdelay', '0'],
                                          stdout=open('/tmp/mongo-temp.log', 'wb'),
                                          stderr=subprocess.STDOUT)
 


### PR DESCRIPTION
To make the tests work for me with MongoDB v4.4.4, I had to remove some
deprecated flags from the mongod.

I am no MongoDB expert and I just removed the flags not known anymore in 4.4.4.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


