### PR TITLE
Handly empty Attributes in Attribute Generation

### DIFF
--- a/src/satosa/micro_services/attribute_generation.py
+++ b/src/satosa/micro_services/attribute_generation.py
@@ -127,7 +127,10 @@ you don't care which value is used in a template.
         context = dict()
 
         for attr_name, values in attributes.items():
-            context[attr_name] = MustachAttrValue(attr_name, values)
+            context[attr_name] = MustachAttrValue(
+                attr_name,
+                values if values is not None else []
+            )
 
         recipes = get_dict_defaults(self.synthetic_attributes, requester, provider)
         for attr_name, fmt in recipes.items():

--- a/tests/satosa/micro_services/test_attribute_generation.py
+++ b/tests/satosa/micro_services/test_attribute_generation.py
@@ -63,3 +63,20 @@ class TestAddSyntheticAttributes:
         assert("kaka1" in resp.attributes['kaka'])
         assert("a@example.com" in resp.attributes['eppn'])
         assert("b@example.com" in resp.attributes['eppn'])
+
+    def test_generate_mustache_empty_attribute(self):
+        synthetic_attributes = {
+           "": {"default": {"a0": "{{kaka.first}}#{{eppn.scope}}"}}
+        }
+        authz_service = self.create_syn_service(synthetic_attributes)
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {
+            "kaka": ["kaka1", "kaka2"],
+            "eppn": None,
+        }
+        ctx = Context()
+        ctx.state = dict()
+        authz_service.process(ctx, resp)
+        assert("kaka1#" in resp.attributes['a0'])
+        assert("kaka1" in resp.attributes['kaka'])
+        assert("kaka2" in resp.attributes['kaka'])


### PR DESCRIPTION
`MustachAttrValue` in `attibute_generation.py` can not handly empty attributes
(`None`), since it expect a list, and crashed hard.
This patch makes sure that `MustachAttrValue` always receives a list as values.
Tests included.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


