### PR TITLE
Set Primary Identifier only if it exists

### DIFF
--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -250,13 +250,14 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
             logger.debug(logline)
             data.attributes = {}
 
-        # Set the primary identifier attribute to the value found.
-        data.attributes[primary_identifier] = primary_identifier_val
-        msg = "{} Setting attribute {} to value {}".format(
-            logprefix, primary_identifier, primary_identifier_val
-        )
-        logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-        logger.debug(logline)
+        if primary_identifier:
+            # Set the primary identifier attribute to the value found.
+            data.attributes[primary_identifier] = primary_identifier_val
+            msg = "{} Setting attribute {} to value {}".format(
+                logprefix, primary_identifier, primary_identifier_val
+            )
+            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+            logger.debug(logline)
 
         msg = "{} returning data.attributes {}".format(logprefix, str(data.attributes))
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)


### PR DESCRIPTION
This patch ensures that the primary identifier is only set, if it is present
and not `None`.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


