### PR TITLE
feat: added some useful http headers to context

### DIFF
--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -65,6 +65,13 @@ def unpack_request(environ, content_length=0):
     return data
 
 
+def unpack_http_headers(environ):
+    headers = ('REQUEST_METHOD', 'PATH_INFO', 'REQUEST_URI',
+               'QUERY_STRING', 'SERVER_NAME', 'REMOTE_ADDR',
+               'HTTP_HOST', 'HTTP_USER_AGENT', 'HTTP_ACCEPT_LANGUAGE')
+    return {k:v for k,v in environ.items() if k in headers}
+
+
 class ToBytesMiddleware(object):
     """Converts a message to bytes to be sent by WSGI server."""
 
@@ -109,6 +116,7 @@ class WsgiApplication(SATOSABase):
         body = io.BytesIO(environ['wsgi.input'].read(content_length))
         environ['wsgi.input'] = body
         context.request = unpack_request(environ, content_length)
+        context._http_headers = unpack_http_headers(environ)
         environ['wsgi.input'].seek(0)
 
         context.cookie = environ.get("HTTP_COOKIE", "")


### PR DESCRIPTION
This PR adds in satosa context object some useful HTTP request headers in a private attribute called `_http_headers`.
these are the following

- REQUEST_METHOD
- PATH_INFO
- REQUEST_URI
- QUERY_STRING
- SERVER_NAME
- REMOTE_ADDR
- HTTP_HOST
- HTTP_USER_AGENT
- HTTP_ACCEPT_LANGUAGE

With these additional values we would allow some highly specialized feature in the future Microservices.
Some example:

- Security: SIEM integrations, checks upon SERVER_NAME, QUERY_STRING, HTTP_USER_AGENT
- i18n: HTTP_ACCEPT_LANGUAGE

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


