### PR TITLE
feat: IdPHinting Microservice - minimal idp_hinting support

### DIFF
--- a/example/plugins/microservices/idp_hinting.yaml.example
+++ b/example/plugins/microservices/idp_hinting.yaml.example
@@ -1,0 +1,6 @@
+module: satosa.micro_services.idp_hinting.IdpHinting
+name: IdpHinting
+config:
+  allowed_params:
+    - idp_hinting
+    - idp_hint

--- a/src/satosa/micro_services/idp_hinting.py
+++ b/src/satosa/micro_services/idp_hinting.py
@@ -1,0 +1,59 @@
+import logging
+from urllib.parse import parse_qs
+
+from .base import RequestMicroService
+from ..exception import SATOSAConfigurationError
+from ..exception import SATOSAError
+
+
+logger = logging.getLogger(__name__)
+
+
+class IdpHintingError(SATOSAError):
+    """
+    SATOSA exception raised by IdpHinting microservice
+    """
+    pass
+
+
+class IdpHinting(RequestMicroService):
+    """
+    Detect if an idp hinting feature have been requested
+    """
+
+    def __init__(self, config, *args, **kwargs):
+        """
+        Constructor.
+        :param config: microservice configuration
+        :type config: Dict[str, Dict[str, str]]
+        """
+        super().__init__(*args, **kwargs)
+        try:
+            self.idp_hint_param_names = config['allowed_params']
+        except KeyError:
+            raise SATOSAConfigurationError(
+                f"{self.__class__.__name__} can't find allowed_params"
+            )
+
+    def process(self, context, data):
+        """
+        This intercepts if idp_hint paramenter is in use
+        :param context: request context
+        :param data: the internal request
+        """
+        target_entity_id = context.get_decoration(context.KEY_TARGET_ENTITYID)
+        qs_raw = context._http_headers['QUERY_STRING']
+        if target_entity_id or not qs_raw:
+            return super().process(context, data)
+
+        qs = parse_qs(qs_raw)
+        hints = (
+            entity_id
+            for param in self.idp_hint_param_names
+            for entity_id in qs.get(param, [None])
+            if entity_id
+        )
+        hint = next(hints, None)
+
+        context.decorate(context.KEY_TARGET_ENTITYID, hint)
+        return super().process(context, data)


### PR DESCRIPTION
This PR allows to circumvent the discovery service screen if a SP that supports idp_hinting includes the idp_hint parameter, or alternative name, in the HTTP parameters of its request. One or more names of this parameter can be defined within the configuration of this new Micro Service.

### Example
The following URL triggers an AuthnRequest to SATOSA, with the idp_hinting parameter

http://sp.example.org/saml2/login/?idp=https://172.17.0.1:10000/Saml2IDP/metadata&next=/saml2/echo_attributes&idphint=http%253A%252F%252Flocalhost%253A8080

The SP that supports idp_hinting used for tests is [djangosaml2](https://djangosaml2.readthedocs.io/).

### Without idp hinting
![satosa1](https://user-images.githubusercontent.com/1297620/114312802-36fa4080-9af4-11eb-8e6e-279b5910f198.gif)

### With IdP Hinting
![satosa2](https://user-images.githubusercontent.com/1297620/114312811-437e9900-9af4-11eb-8f2d-9bc2e3cbb647.gif)

### Dependency
This PR depends on this PR:
https://github.com/IdentityPython/SATOSA/pull/365

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


