### PR TITLE
PrimaryIdentifier microservice enhancements (and misc typo fixes)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -661,7 +661,7 @@ methods:
 * Frontends must inherit `satosa.frontends.base.FrontendModule`.
 * Backends must inherit `satosa.backends.base.BackendModule`.
 * Request micro services must inherit `satosa.micro_services.base.RequestMicroService`.
-* Request micro services must inherit `satosa.micro_services.base.ResponseMicroService`.
+* Response micro services must inherit `satosa.micro_services.base.ResponseMicroService`.
 
 # <a name="saml_metadata" style="color:#000000">Generate proxy metadata</a>
 

--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -7,7 +7,7 @@ config:
   # the authenticating IdP, or the entityID of the CO virtual IdP.
   # The key "default" specifies the default configuration
   default:
-      ldap_url: ldaps://ldap.example.org
+      ldap_url: "ldaps://ldap.example.org"
       bind_dn: cn=admin,dc=example,dc=org
       # Obtain bind password from environment variable LDAP_BIND_PASSWORD.
       bind_password: !ENV LDAP_BIND_PASSWORD
@@ -114,7 +114,7 @@ config:
     user_id_from_attrs:
       - uid
 
-  https://federation-proxy.my.edu/satosa/idp/proxy/some_co
+  https://federation-proxy.my.edu/satosa/idp/proxy/some_co:
     search_base: ou=People,o=some_co,dc=example,dc=org
 
   # The microservice may be configured to ignore a particular entityID.

--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -1,4 +1,4 @@
-module: LdapAttributeStore
+module: satosa.micro_services.ldap_attribute_store.LdapAttributeStore
 name: LdapAttributeStore
 config:
 

--- a/example/plugins/microservices/primary_identifier.yaml.example
+++ b/example/plugins/microservices/primary_identifier.yaml.example
@@ -1,4 +1,4 @@
-module: PrimaryIdentifier
+module: satosa.micro_services.primary_identifier.PrimaryIdentifier
 name: PrimaryIdentifier
 config:
     # The ordered identifier candidates are searched in order

--- a/example/plugins/microservices/primary_identifier.yaml.example
+++ b/example/plugins/microservices/primary_identifier.yaml.example
@@ -34,6 +34,8 @@ config:
     # Whether or not to clear the input attributes after setting the
     # primary identifier value.
     clear_input_attributes: no
+    # Whether to replace subject_id with the constructed primary identifier
+    replace_subject_id: no
     # If defined redirect to this page if no primary identifier can
     # be found.
     on_error: https://my.org/errors/no_primary_identifier

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -250,7 +250,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         # Clear input attributes if so configured.
         if clear_input_attributes:
             msg = "{} Clearing values for these input attributes: {}".format(
-                logprefix, data.attribute_names
+                logprefix, data.attributes.keys()
             )
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.debug(logline)

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -54,7 +54,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
 
             # Get the values asserted by the IdP for the configured list of attribute names for this candidate
             # and substitute None if the IdP did not assert any value for a configured attribute.
-            values = [ attributes.get(attribute_name, [None])[0] for attribute_name in candidate['attribute_names'] ]
+            values = [ attributes.get(attribute_name, [None])[0] for attribute_name in candidate['attribute_names'] if attribute_name != 'name_id' ]
             msg = "{} Found candidate values {}".format(logprefix, values)
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.debug(logline)

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -31,7 +31,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         super().__init__(*args, **kwargs)
         self.config = config
 
-    def constructPrimaryIdentifier(self, data, ordered_identifier_candidates, clear_input_attributes=False):
+    def constructPrimaryIdentifier(self, data, ordered_identifier_candidates):
         """
         Construct and return a primary identifier value from the
         data asserted by the IdP using the ordered list of candidates
@@ -120,18 +120,6 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
 
             # Concatenate all values to create the primary identifier.
             value = ''.join(values)
-
-            # Clear input attributes if so configured.
-            if clear_input_attributes:
-                attributes_to_clear = [attribute_name for attribute_name in candidate['attribute_names'] if attribute_name != 'name_id']
-                msg = "{} Clearing values for these input attributes: {}".format(
-                    logprefix, attributes_to_clear
-                )
-                logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-                logger.debug(logline)
-                for attribute in attributes_to_clear:
-                    del data.attributes[attribute]
-
             break
 
         return value
@@ -237,7 +225,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         msg = "{} Constructing primary identifier".format(logprefix)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
-        primary_identifier_val = self.constructPrimaryIdentifier(data, ordered_identifier_candidates, clear_input_attributes)
+        primary_identifier_val = self.constructPrimaryIdentifier(data, ordered_identifier_candidates)
 
         if not primary_identifier_val:
             msg = "{} No primary identifier found".format(logprefix)
@@ -258,6 +246,15 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         msg = "{} Found primary identifier: {}".format(logprefix, primary_identifier_val)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.info(logline)
+
+        # Clear input attributes if so configured.
+        if clear_input_attributes:
+            msg = "{} Clearing values for these input attributes: {}".format(
+                logprefix, data.attribute_names
+            )
+            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+            logger.debug(logline)
+            data.attributes = {}
 
         if primary_identifier:
             # Set the primary identifier attribute to the value found.

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -205,7 +205,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
                 clear_input_attributes = False
             if 'replace_subject_id' in config:
                 replace_subject_id = config['replace_subject_id']
-            elif 'clear_input_attributes' in self.config:
+            elif 'replace_subject_id' in self.config:
                 replace_subject_id = self.config['replace_subject_id']
             else:
                 replace_subject_id = False

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -31,7 +31,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         super().__init__(*args, **kwargs)
         self.config = config
 
-    def constructPrimaryIdentifier(self, data, ordered_identifier_candidates):
+    def constructPrimaryIdentifier(self, data, ordered_identifier_candidates, clear_input_attributes=False):
         """
         Construct and return a primary identifier value from the
         data asserted by the IdP using the ordered list of candidates
@@ -120,6 +120,18 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
 
             # Concatenate all values to create the primary identifier.
             value = ''.join(values)
+
+            # Clear input attributes if so configured.
+            if clear_input_attributes:
+                attributes_to_clear = [attribute_name for attribute_name in candidate['attribute_names'] if attribute_name != 'name_id']
+                msg = "{} Clearing values for these input attributes: {}".format(
+                    logprefix, attributes_to_clear
+                )
+                logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+                logger.debug(logline)
+                for attribute in attributes_to_clear:
+                    del data.attributes[attribute]
+
             break
 
         return value
@@ -225,7 +237,7 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         msg = "{} Constructing primary identifier".format(logprefix)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
-        primary_identifier_val = self.constructPrimaryIdentifier(data, ordered_identifier_candidates)
+        primary_identifier_val = self.constructPrimaryIdentifier(data, ordered_identifier_candidates, clear_input_attributes)
 
         if not primary_identifier_val:
             msg = "{} No primary identifier found".format(logprefix)
@@ -246,15 +258,6 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
         msg = "{} Found primary identifier: {}".format(logprefix, primary_identifier_val)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.info(logline)
-
-        # Clear input attributes if so configured.
-        if clear_input_attributes:
-            msg = "{} Clearing values for these input attributes: {}".format(
-                logprefix, data.attribute_names
-            )
-            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-            logger.debug(logline)
-            data.attributes = {}
 
         if primary_identifier:
             # Set the primary identifier attribute to the value found.

--- a/src/satosa/micro_services/primary_identifier.py
+++ b/src/satosa/micro_services/primary_identifier.py
@@ -191,6 +191,12 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
                 clear_input_attributes = self.config['clear_input_attributes']
             else:
                 clear_input_attributes = False
+            if 'replace_subject_id' in config:
+                replace_subject_id = config['replace_subject_id']
+            elif 'clear_input_attributes' in self.config:
+                replace_subject_id = self.config['replace_subject_id']
+            else:
+                replace_subject_id = False
             if 'ignore' in config:
                 ignore = True
             else:
@@ -258,6 +264,15 @@ class PrimaryIdentifier(satosa.micro_services.base.ResponseMicroService):
             )
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.debug(logline)
+
+        # Replace subject_id with the constructed primary identifier if so configured.
+        if replace_subject_id:
+            msg = "{} Setting subject_id to value {}".format(
+                logprefix, primary_identifier_val
+            )
+            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+            logger.debug(logline)
+            data.subject_id = primary_identifier_val
 
         msg = "{} returning data.attributes {}".format(logprefix, str(data.attributes))
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)


### PR DESCRIPTION
### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [No] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

Hi,

I'm deploying SATOSA with an OpenIDConnect front-end and SAML2 backend - to allow connecting OpenIDConnect services into our SAML federation (Tuakiri).

As some of our IdPs use eduPersonTargetedID while most uses SAML2 Persistent NameID, I need the PrimaryIdentifier MicroService to allow pulling the right identifier (either EPTID or NameID) from what the SAML2 backend received.

However, I ran into several issues:
* the way attribute values were pulled based on attribute name, `name_id` could not be used - fixed in cba6cd0
* I needed a way to replace the `subject_id` with the value constructed by the PrimaryIdentifier MicroService.  Even though this would ideally be configured via `user_id_from_attrs` in `internal_attributes.yaml`, I could not use this path - as `_auth_resp_callback_func` in `satosa/base.py` processes `user_id_from_attrs` BEFORE calling ResponseMicroServices; the PrimaryIdentifier MicroService comes in too late.  Hence I added a new option `replace_subject_id` for this MicroService in 4d3020e
* while in the code, I saw that the `clear_input_attributes` functionality would not work, so I included a fix for that as well ( 8ae4696 )
* And I've fixed some typos/omissions in the example files and documentation.

Please let me know if any of this needs further clarification or improvement of this is OK to merge.

Thanks a lot in advance for getting back to me.

Cheers,
Vlad

