### PR TITLE
SAML2 frontend+backend: support reloading metadata

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -8,6 +8,7 @@ config:
   memorize_idp: no
   use_memorized_idp_when_force_authn: no
   send_requester_id: no
+  enable_metadata_reload: no
 
   sp_config:
     key_file: backend.key

--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -2,6 +2,7 @@ module: satosa.frontends.saml2.SAMLFrontend
 name: Saml2IDP
 config:
   entityid_endpoint: true
+  enable_metadata_reload: no
   idp_config:
     organization: {display_name: Example Identities, name: Example Identities Org., url: 'http://www.example.com'}
     contact_person:

--- a/example/plugins/frontends/saml2_virtualcofrontend.yaml.example
+++ b/example/plugins/frontends/saml2_virtualcofrontend.yaml.example
@@ -94,6 +94,8 @@ config:
       'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST': sso/post
       'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect': sso/redirect
 
+  enable_metadata_reload: no
+
   # If configured and not false or empty the common domain cookie _saml_idp will be set
   # with or have appended the IdP used for authentication. The default is not to set the
   # cookie. If the value is a dictionary with key 'domain' then the domain for the cookie

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -261,6 +261,7 @@ class SATOSABase(object):
 
 class SAMLBaseModule(object):
     KEY_ENTITYID_ENDPOINT = 'entityid_endpoint'
+    KEY_ENABLE_METADATA_RELOAD = 'enable_metadata_reload'
     KEY_ATTRIBUTE_PROFILE = 'attribute_profile'
     KEY_ACR_MAPPING = 'acr_mapping'
     VALUE_ATTRIBUTE_PROFILE_DEFAULT = 'saml'
@@ -274,6 +275,15 @@ class SAMLBaseModule(object):
 
     def expose_entityid_endpoint(self):
         value = self.config.get(self.KEY_ENTITYID_ENDPOINT, False)
+        return bool(value)
+
+    def enable_metadata_reload(self):
+        """
+        Check whether metadata reload has been enabled in config
+
+        return: bool
+        """
+        value = self.config.get(self.KEY_ENABLE_METADATA_RELOAD, False)
         return bool(value)
 
 


### PR DESCRIPTION
Using the reload_metadata method added into pysaml2 in IdentityPython/pysaml2#809, support reloading metadata when triggered via an externally exposed URL (as `/<module_name>/reload-metadata`)

This is off by default (URL not exposed) and needs to be explicitly enabled by setting the newly introduced config option `enable_metadata_reload` for the SAML modules to `true` (or `yes`).

The loaded config is already preserved in the modules, so can be easily used to provide a reference copy of the metadata configuration to the `reload_metadata` method.

This is implemented separately for the SAML2 Backend and SAML2 Frontend (applying to all three SAML2 Frontend classes).

This will complete the missing functionality identified in IdentityPython/pysaml2#808

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [Not yet] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


