### PR TITLE
Add isMemberOf to basic attribute map

### DIFF
--- a/docker/attributemaps/basic.py
+++ b/docker/attributemaps/basic.py
@@ -84,6 +84,7 @@ MAP = {
         DEF+'info': 'info',
         DEF+'initials': 'initials',
         DEF+'internationaliSDNNumber': 'internationaliSDNNumber',
+        DEF+'isMemberOf': 'isMemberOf',
         DEF+'janetMailbox': 'janetMailbox',
         DEF+'jpegPhoto': 'jpegPhoto',
         DEF+'knowledgeInformation': 'knowledgeInformation',


### PR DESCRIPTION
We use this attribute, it was missing from the default shipped maps.
