### PR TITLE
better endpoint config example for saml2 backend

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -51,9 +51,9 @@ config:
         allow_unsolicited: true
         endpoints:
           assertion_consumer_service:
-          - [<base_url>/<name>/acs/post, 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']
+          - [/<name>/acs/post, 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']
           discovery_response:
-          - [<base_url>/<name>/disco, 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol']
+          - [/<name>/disco, 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol']
         name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
         # A name_id_format of 'None' will cause the authentication request to not
         # include a Format attribute in the NameIDPolicy.


### PR DESCRIPTION
This modification compensates a problematic line here (and the other line for the disco endpoint): 
https://github.com/IdentityPython/SATOSA/blob/84cf60fd38de06a85d6f9d39ef364a3d12571120/src/satosa/backends/saml2.py#L455

If your base_url is like https://www.example.com then this information will be merely thrown away and satosa works.

If your base_url is like https://www.example.com/satosa then you will end up with an endpoint incorrectly registered as satosa/Saml2/acs/post 
Then, the deployment will yield this error:

'Saml2/acs/post' not bound to any function

Which is per se correct as it was registered under another name.
So since the baseurl is thrown away anyway it is better not to have it in the first place.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


