### PR TITLE
Fix tests due to release of pyop v3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install tox-travis
 
 script:
-  - tox
+  - tox -r
 
 jobs:
   allow_failures:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages('src/'),
     package_dir={'': 'src'},
     install_requires=[
-        "pyop >= 3.0.1",
+        "pyop >= 3.2.0",
         "pysaml2 >= 6.5.1",
         "pycryptodomex",
         "requests",
@@ -27,7 +27,9 @@ setup(
         "cookies-samesite-compat",
     ],
     extras_require={
-        "ldap": ["ldap3"]
+        "ldap": ["ldap3"],
+        "pyop_mongo": ["pyop[mongo]"],
+        "pyop_redis": ["pyop[redis]"],
     },
     zip_safe=False,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 deps = -rtests/test_requirements.txt
-whitelist_externals =
+allowlist_externals =
   tox
   xmlsec1
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,13 @@ envlist =
   pypy3
 
 [testenv]
+skip_install = true
 deps = -rtests/test_requirements.txt
 allowlist_externals =
   tox
   xmlsec1
 commands =
+  pip install -U .[pyop_mongo]
   xmlsec1 --version
   python --version
   pytest --version

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ allowlist_externals =
   tox
   xmlsec1
 commands =
+  pip install -U pip wheel setuptools
   pip install -U .[pyop_mongo]
   xmlsec1 --version
   python --version

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
   py36
   py37
+  py38
+  py39
   pypy3
 
 [testenv]


### PR DESCRIPTION
Fix tests after new version of pyop (v3.2.0) not pulling pymongo anymore.


### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


