### PR TITLE
Make "kid" configurable for the openid_connect frontend

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -2,6 +2,7 @@ module: satosa.frontends.openid_connect.OpenIDConnectFrontend
 name: OIDC
 config:
   signing_key_path: frontend.key
+  signing_key_id: frontend.key1
   db_uri: mongodb://db.example.com # optional: only support MongoDB, will default to in-memory storage if not specified
   client_db_path: /path/to/your/cdb.json
   sub_hash_salt: randomSALTvalue # if not specified, it is randomly generated on every startup

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -44,7 +44,8 @@ class OpenIDConnectFrontend(FrontendModule):
         super().__init__(auth_req_callback_func, internal_attributes, base_url, name)
 
         self.config = conf
-        self.signing_key = RSAKey(key=rsa_load(conf["signing_key_path"]), use="sig", alg="RS256")
+        self.signing_key = RSAKey(key=rsa_load(conf["signing_key_path"]), use="sig", alg="RS256",
+                                  kid=conf.get("signing_key_id", ""))
 
     def _create_provider(self, endpoint_baseurl):
         response_types_supported = self.config["provider"].get("response_types_supported", ["id_token"])
@@ -239,6 +240,10 @@ class OpenIDConnectFrontend(FrontendModule):
         for k in {"signing_key_path", "provider"}:
             if k not in config:
                 raise ValueError("Missing configuration parameter '{}' for OpenID Connect frontend.".format(k))
+
+        if "signing_key_id" in config and type(config["signing_key_id"]) is not str:
+            raise ValueError(
+                "The configuration parameter 'signing_key_id' is not defined as a string for OpenID Connect frontend.")
 
     def _get_authn_request_from_state(self, state):
         """


### PR DESCRIPTION
SATOSA `OpenIDConnectFrontend` `.well-known/openid-configuration` endpoint has the `jwks_uri` which shows the jwks json, containing a signing key that may be used by the OIDC clients to verify the signature of the id_token. But this jwks, does not currently contain the `kid` element of the jwk.

This pull request adds the `kid` in the jwks if it is configured via the new "signing_key_id" configuration parameter in the openid_connect_frontend.yaml. When initializing `jwkest.jwk.RSAKey` in `OpenIDConnectFrontend`, `kid` needs to be specified, and everything else will automatically be handled by the jwkest python module.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


