### PR TITLE
fix: do not pass extra arg to logging.error

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -185,7 +185,7 @@ class SATOSABase(object):
                 err_id=error.error_id, state=state
             )
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-            logger.error(logline, error.state, exc_info=True)
+            logger.error(logline, exc_info=True)
             return self._handle_satosa_authentication_error(error)
 
     def _load_state(self, context):


### PR DESCRIPTION
SATOSA formats all log messages explicitly before passing them to the logger.

Python logging formats messages if it receives extra args in the call,
otherwise pass them straight through.

This call to logger.error in _run_bound_endpoint was (accidentally)
passing an extra argument error.state, causing logging to do another
round of formatting on an already formatted message.

This is dangerous, as the text of the (already formatted) message may contain
externally supplied data - such as the redirect URI with URI-encoded data like %3A#2F
(which in best part just throw another exception - "Unknown formatting character A")

State is already included in the explicit message formatting, so the extra argument
here should be safe to remove.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [N/A] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


