### PR TITLE
fix: add missing pip dependencies for new OIDC frontend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
         "click",
         "chevron",
         "cookies-samesite-compat",
+        "oidcop",
+        "pymongo",
     ],
     extras_require={
         "ldap": ["ldap3"],


### PR DESCRIPTION
new OIDC frontend uses cryptojwt and oidcmsg, but they were missing in setup.py

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* N/A Have you added an explanation of what problem you are trying to solve with this PR?
* N/A Have you added information on what your changes do and why you chose this as your solution?
* N/A Have you written new tests for your changes?
* N/A Does your submission pass tests?
* N/A This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
