### PR TITLE
fix: correct return variable in github backend

### DIFF
--- a/src/satosa/backends/github.py
+++ b/src/satosa/backends/github.py
@@ -108,4 +108,4 @@ class GitHubBackend(_OAuthBackend):
         r = requests.get(url, headers=headers)
         ret = r.json()
         ret['id'] = str(ret['id'])
-        return r.json()
+        return ret


### PR DESCRIPTION
convert GitHub id into string to avoid TypeError

There is a piece of code which tries to convert the numeric id into a string, but then the original (unchanged) variable is returned. That causes a TypeError when GitHub id is used for user_id (user_id_from_attrs).

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?