### PR TITLE
Fix open redirect in OpenID connect frontend

### DIFF
--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -297,11 +297,17 @@ class OpenIDConnectFrontend(FrontendModule):
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.error(logline)
             error_url = e.to_error_url()
+            if "redirect_uri" in context.request:
+                redirect_uri = context.request["redirect_uri"]
+            else:
+                redirect_uri = False
 
             if error_url:
-                return SeeOther(error_url)
+                return BadRequest("Something went wrong: {}. Not redirecting to external URL {}.".format(str(e), error_url))
+            elif redirect_uri:
+                return BadRequest("Something went wrong: {}. Not redirecting to external URL {}.".format(str(e), redirect_uri))
             else:
-                return BadRequest("Something went wrong: {}".format(str(e)))
+                return BadRequest("Something went wrong: {}.".format(str(e)))
 
         client_id = authn_req["client_id"]
         context.state[self.name] = {"oidc_request": request}


### PR DESCRIPTION
## Open redirect in OpenID connect frontend

When running Satosa from the satosa/satosa docker image, the URL:

`http://<your hostname>/<path to your OpenID authorization_endpoint>?response_type=code&client_id=something&scope=openid&redirect_uri=<evil url>`

Redirects to **evil url**.

This seems unwanted behaviour to me, because evil_person can use this open redirect to create a link which points  to a trusworthy domain (**your hostname**) but redirects to a host (**evil url**) under the control of evil_person. This could for example be used in phishing attacks.

I tested this with docker images satosa/satosa:v6.1.0, satosa/satosa:v7.0.3, and satosa/satosa:latest (which at the moment of writing also uses Satosa version 7.0.3).

It seems to me that version 8.0.0 is also vulnerable, but since I did not have an 8.0.0. docker image to test this with, I created a simple fix for the last stable version in use with the satosa/satosa docker image, that is 7.0.3.

This may be too quick and dirty to be merged as-is, but I had to fix our Satosa installations on short notice and this is the best I could come up with. Authorization failures now no longer redirect to external URLs, but show the error on the host where Satosa is running (`BadRequest` instead of `SeeOther`).

Hopefully this will be helpful to you anyway.
