### PR TITLE
docs: add name and description to example SAML2 backend

### DIFF
--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -18,6 +18,8 @@ config:
   enable_metadata_reload: no
 
   sp_config:
+    name: "SP Name"
+    description: "SP Description"
     key_file: backend.key
     cert_file: backend.crt
     organization: {display_name: Example Identities, name: Example Identities Org., url: 'http://www.example.com'}


### PR DESCRIPTION
These attributes are required to generate valid metadata in combination with required_attributes and/or optional_attributes.

Without these attributes specified (and there is no hint in [pysaml2 docs](https://pysaml2.readthedocs.io/) about this either), the generated metadata contains empty `<ns0:ServiceName xml:lang="en" />` inside `AttributeConsumingService`, which is invalid. This was probably the cause of [pysaml2#345](https://github.com/IdentityPython/pysaml2/issues/345)