### PR TITLE
docs: fix disco_srv nesting in README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -380,8 +380,8 @@ parameter `disco_srv`, must be specified if the metadata given to the backend mo
 
 ```yaml
 config:
+  disco_srv: http://disco.example.com
   sp_config: [...]
-    disco_srv: http://disco.example.com
 ```
 
 ##### Mirror the SAML ForceAuthn option


### PR DESCRIPTION
disco_srv needs to be in the top-level config, not under sp_config

It is correct in the [example](https://github.com/IdentityPython/SATOSA/blob/7e7241f7bbdccd026bab2cfd508935d11d183903/example/plugins/backends/saml2_backend.yaml.example) and in the [tests](https://github.com/IdentityPython/SATOSA/blob/1def9986e5c32baa5f95be835cf5843d9f9ab5d8/tests/satosa/backends/test_saml2.py), but incorrect in the README
