### PR TITLE
Add option pool_lifetime option to ldap

### DIFF
--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -27,6 +27,9 @@ config:
       # pool_keepalive: seconds to wait between calls to server to keep the
       # connection alive; default: 10
       pool_keepalive: 10
+      # pool_lifetime: number of seconds before recreating a new connection
+      # in a pooled connection strategy.
+      pool_lifetime: None
 
       # Attributes to return from LDAP query.
       query_return_attributes:

--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -61,6 +61,7 @@ class LdapAttributeStore(ResponseMicroService):
         "client_strategy": "REUSABLE",
         "pool_size": 10,
         "pool_keepalive": 10,
+        "pool_lifetime": None,
     }
 
     def __init__(self, config, *args, **kwargs):
@@ -307,6 +308,7 @@ class LdapAttributeStore(ResponseMicroService):
 
         pool_size = config["pool_size"]
         pool_keepalive = config["pool_keepalive"]
+        pool_lifetime = config["pool_lifetime"]
         pool_name = ''.join(random.sample(string.ascii_lowercase, 6))
 
         if client_strategy == ldap3.REUSABLE:
@@ -314,6 +316,9 @@ class LdapAttributeStore(ResponseMicroService):
             logger.debug(msg)
             msg = "Using pool keep alive {}".format(pool_keepalive)
             logger.debug(msg)
+            if pool_lifetime:
+                msg = "Using pool lifetime {}".format(pool_lifetime)
+                logger.debug(msg)
 
         try:
             connection = ldap3.Connection(
@@ -327,6 +332,7 @@ class LdapAttributeStore(ResponseMicroService):
                 pool_name=pool_name,
                 pool_size=pool_size,
                 pool_keepalive=pool_keepalive,
+                pool_lifetime=pool_lifetime,
             )
             msg = "Successfully connected to LDAP server"
             logger.debug(msg)


### PR DESCRIPTION
This patch adds another option to the ldap connection. Next to the other pool
connections, it is now possible to set the `pool_lifetime`.

Some LDAP Server abandon connections after some time without notifying the client. This option allow to set a maximal pool lifetime, to also close connections on the client.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


