### PR TITLE
Add option search_filter to ldap

### DIFF
--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -85,8 +85,10 @@ config:
       ldap_identifier_attribute: uid
 
       # Override the contructed search_filter with ldap_identifier_attribute
-      # with an own filter. This allows more komplex queries.
+      # with an own filter. This allows more complex queries.
       # {0} will be injected with the ordered_identifier_candidates.
+      # For example:
+      # search_filter: "(&(uid={0})(isMemberOf=authorized))"
       search_filter: None
 
       # Whether to clear values for attributes incoming

--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -84,6 +84,11 @@ config:
 
       ldap_identifier_attribute: uid
 
+      # Override the contructed search_filter with ldap_identifier_attribute
+      # with an own filter. This allows more komplex queries.
+      # {0} will be injected with the ordered_identifier_candidates.
+      search_filter: None
+
       # Whether to clear values for attributes incoming
       # to this microservice. Default is no or false.
       clear_input_attributes: no

--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -46,6 +46,7 @@ class LdapAttributeStore(ResponseMicroService):
         "clear_input_attributes": False,
         "ignore": False,
         "ldap_identifier_attribute": None,
+        "search_filter": None,
         "ldap_url": None,
         "ldap_to_internal_map": None,
         "on_ldap_search_result_empty": None,
@@ -473,8 +474,11 @@ class LdapAttributeStore(ResponseMicroService):
         logger.debug(logline)
 
         for filter_val in filter_values:
-            ldap_ident_attr = config["ldap_identifier_attribute"]
-            search_filter = "({0}={1})".format(ldap_ident_attr, filter_val)
+            if config["search_filter"]:
+                search_filter = config["search_filter"].format(filter_val)
+            else:
+                ldap_ident_attr = config["ldap_identifier_attribute"]
+                search_filter = "({0}={1})".format(ldap_ident_attr, filter_val)
             msg = {
                 "message": "LDAP query with constructed search filter",
                 "search filter": search_filter,


### PR DESCRIPTION
This patch adds the option to override the search_filter in ldap with an own
complex search_filter, because sometimes a single simple argument is not
sufficient.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


