### PR TITLE
Select LDAP config by extracted attribute

### DIFF
--- a/example/plugins/microservices/ldap_attribute_store.yaml.example
+++ b/example/plugins/microservices/ldap_attribute_store.yaml.example
@@ -97,13 +97,23 @@ config:
       # from LDAP. The default is not to redirect.
       on_ldap_search_result_empty: https://my.vo.org/please/go/enroll
 
-  # The microservice may be configured per entityID.
+  # The microservice may be configured per entityID or per extracted attribute.
   # The configuration key is the entityID of the requesting SP,
-  # the authenticating IdP, or the entityID of the CO virtual IdP.
-  # When more than one configured entityID matches during a flow
-  # the priority ordering is requesting SP, then authenticating IdP, then
+  # the authenticating IdP, the entityID of the CO virtual IdP, or the
+  # extracted attribute defined by `global.provider_attribute`.
+  # When more than one configured key matches during a flow
+  # the priority ordering is provider attribute, requesting SP, then authenticating IdP, then
   # CO virtual IdP. Αny missing parameters are taken from the
   # default configuration.
+  global:
+    provider_attribute: domain
+
+  # domain attribute is extracted in a previous microserver and used as a key
+  # here.
+  company.com:
+    ldap_url: ldaps://ldap.company.com
+    search_base: ou=group,dc=identity,dc=company,dc=com
+
   https://sp.myserver.edu/shibboleth-sp:
     search_base: ou=People,o=MyVO,dc=example,dc=org
     search_return_attributes:
@@ -120,3 +130,4 @@ config:
   # The microservice may be configured to ignore a particular entityID.
   https://another.sp.myserver.edu:
     ignore: true
+

--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -81,9 +81,15 @@ class LdapAttributeStore(ResponseMicroService):
 
         self.config = {}
 
+        # Get provider attribute
+        self.provider_attribute = None
+        if "global" in config:
+            if "provider_attribute" in config["global"]:
+                self.provider_attribute = config["global"]["provider_attribute"]
+
         # Process the default configuration first then any per-SP overrides.
         sp_list = ["default"]
-        sp_list.extend([key for key in config.keys() if key != "default"])
+        sp_list.extend([key for key in config.keys() if key != "default" and key != "global"])
 
         connections = {}
 
@@ -412,6 +418,14 @@ class LdapAttributeStore(ResponseMicroService):
         co_entity_id = state.get(frontend_name, {}).get(co_entity_id_key)
 
         entity_ids = [requester, issuer, co_entity_id, "default"]
+        if self.provider_attribute:
+            try:
+                entity_ids.insert(
+                    0,
+                    data.attributes[self.provider_attribute][0]
+                )
+            except (KeyError, IndexError):
+                pass
 
         config, entity_id = next((self.config.get(e), e)
                                  for e in entity_ids if self.config.get(e))


### PR DESCRIPTION
This patch introduces a new global config variable `provider_attribute` to make
it possible to select the config not only by entity but also select the config
variable by a previous set attribute.
This way it is possible to use a single point of authentication, but enrich the
information from different ldap server based on e.g. the domain attribute
extracted in previous steps.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


