### PR TITLE
oidc_frontend: Add option to mirror public subject

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -433,6 +433,7 @@ The configuration parameters available:
 * `client_db_uri`: connection URI to MongoDB or Redis instance where the client data will be persistent, if it's not specified the clients list will be received from the `client_db_path`.
 * `client_db_path`: path to a file containing the client database in json format. It will only be used if `client_db_uri` is not set. If `client_db_uri` and `client_db_path` are not set, clients will only be stored in-memory (not suitable for production use).
 * `sub_hash_salt`: salt which is hashed into the `sub` claim. If it's not specified, SATOSA will generate a random salt on each startup, which means that users will get new `sub` value after every restart.
+* `sub_mirror_subject` (default: `No`): if this is set to `Yes` and SATOSA releases a public `sub` claim to the client, then the subject identifier received from the backend will be mirrored to the client. The default is to hash the public subject identifier with `sub_hash_salt`. Pairwise `sub` claims are always hashed.
 * `provider`: provider configuration information. MUST be configured, the following configuration are supported:
     * `response_types_supported` (default: `[id_token]`): list of all supported response types, see [Section 3 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).
     * `subject_types_supported` (default: `[pairwise]`): list of all supported subject identifier types, see [Section 8 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes)

--- a/tests/satosa/frontends/test_openid_connect.py
+++ b/tests/satosa/frontends/test_openid_connect.py
@@ -402,6 +402,26 @@ class TestOpenIDConnectFrontend(object):
         provider_info = ProviderConfigurationResponse().deserialize(frontend.provider_config(None).message, "json")
         assert ("registration_endpoint" in provider_info) == client_registration_enabled
 
+    @pytest.mark.parametrize("sub_mirror_public", [
+        True,
+        False
+    ])
+    def test_mirrored_subject(self, context, frontend_config, authn_req, sub_mirror_public):
+        frontend_config["sub_mirror_public"] = sub_mirror_public
+        frontend_config["provider"]["subject_types_supported"] = ["public"]
+        frontend = self.create_frontend(frontend_config)
+
+        self.insert_client_in_client_db(frontend, authn_req["redirect_uri"])
+        internal_response = self.setup_for_authn_response(context, frontend, authn_req)
+        http_resp = frontend.handle_authn_response(context, internal_response)
+
+        resp = AuthorizationResponse().deserialize(urlparse(http_resp.message).fragment)
+        id_token = IdToken().from_jwt(resp["id_token"], key=[frontend.signing_key])
+        if sub_mirror_public:
+            assert id_token["sub"] == OIDC_USERS["testuser1"]["eduPersonTargetedID"][0]
+        else:
+            assert id_token["sub"] != OIDC_USERS["testuser1"]["eduPersonTargetedID"][0]
+
     def test_token_endpoint(self, context, frontend_config, authn_req):
         token_lifetime = 60 * 60 * 24
         frontend_config["provider"]["access_token_lifetime"] = token_lifetime


### PR DESCRIPTION
Add `sub_mirror_subject` configuration parameter. If this is set to
true, the subject received from the backend will be mirrored to the
client, if public sub is used. To maintain backwards compatibility, the
default value is false.

MirrorPublicSubjectIdentifierFactory would normally belong to pyop, but
in order to keep the code and the configuration in the same place, this
code overloads pyop's HashBasedSubjectIdentifierFactory.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


