### PR TITLE
saml2 backend: support using multiple ACS URLs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -414,6 +414,26 @@ config:
   [...]
 ```
 
+#### Assertion Consumer Service selection
+
+When SATOSA sends the SAML2 authentication request to the IDP, it always
+specifies the AssertionConsumerServiceURL and binding. When
+`acs_selection_strategy` configuration option is set to `use_first_acs` (the
+default), then the first element of the `assertion_consumer_service` list will
+be selected. If `acs_selection_strategy` is `prefer_matching_host`, then SATOSA
+will try to select the `assertion_consumer_service`, which matches the host in
+the HTTP request (in simple words, it tries to select an ACS that matches the
+URL in the user's browser). If there is no match, it will fall back to using the
+first assertion consumer service.
+
+Default value: `use_first_acs`.
+
+```yaml
+config:
+  acs_selection_strategy: prefer_matching_host
+  [...]
+```
+
 ## OpenID Connect plugins
 
 ### OIDC Frontend

--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -16,6 +16,7 @@ config:
   use_memorized_idp_when_force_authn: no
   send_requester_id: no
   enable_metadata_reload: no
+  acs_selection_strategy: prefer_matching_host
 
   sp_config:
     name: "SP Name"

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -298,7 +298,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         except Exception as e:
             msg = "Failed to construct the AuthnRequest for state"
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-            logger.debug(logline, exc_info=True)
+            logger.error(logline, exc_info=True)
             raise SATOSAAuthenticationError(context.state, "Failed to construct the AuthnRequest") from e
 
         if self.sp.config.getattr('allow_unsolicited', 'sp') is False:
@@ -313,15 +313,45 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         return make_saml_response(binding, http_info)
 
     def _get_acs(self, context):
-        """Select the AssertionConsumerServiceURL and binding based on the request"""
-        acs_config = self.sp.config.getattr("endpoints", "sp")["assertion_consumer_service"]
+        """
+        Select the AssertionConsumerServiceURL and binding.
+
+        :param context: The current context
+        :type context: satosa.context.Context
+        :return: Selected ACS URL and binding
+        :rtype: tuple(str, str)
+        """
+        acs_strategy = self.config.get("acs_selection_strategy", "use_first_acs")
+        if acs_strategy == "use_first_acs":
+            acs_strategy_fn = self._use_first_acs
+        elif acs_strategy == "prefer_matching_host":
+            acs_strategy_fn = self._prefer_matching_host
+        else:
+            msg = "Invalid value for '{}' ({}). Using the first ACS instead".format(
+                "acs_selection_strategy", acs_strategy
+            )
+            logger.error(msg)
+            acs_strategy_fn = self._use_first_acs
+        return acs_strategy_fn(context)
+
+    def _use_first_acs(self, context):
+        return self.sp.config.getattr("endpoints", "sp")["assertion_consumer_service"][
+            0
+        ]
+
+    def _prefer_matching_host(self, context):
+        acs_config = self.sp.config.getattr("endpoints", "sp")[
+            "assertion_consumer_service"
+        ]
         try:
             hostname = context.http_headers["HTTP_HOST"]
             for acs, binding in acs_config:
                 parsed_acs = urlparse(acs)
                 if hostname == parsed_acs.netloc:
                     msg = "Selected ACS '{}' based on the request".format(acs)
-                    logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+                    logline = lu.LOG_FMT.format(
+                        id=lu.get_session_id(context.state), message=msg
+                    )
                     logger.debug(logline)
                     return acs, binding
         except (TypeError, KeyError):
@@ -332,7 +362,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         )
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
-        return acs_config[0]
+        return self._use_first_acs(context)
 
     def authn_response(self, context, binding):
         """


### PR DESCRIPTION
When Satosa sends out a SAML2 AuthnRequest, it specifies the AssertionConsumerServiceUrl parameter as well, unless the `hide_assertion_consumer_service` configuration parameter is set. However, Satosa might be deployed in an environment where not all interfaces and host names are accessible for all users. After this change, Satosa tries to select the ACS URL based on the current request, and falls back to the first ACS if there is no match.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


