### PR TITLE
fix(attribute_generation): run mustach only on strings

### DIFF
--- a/src/satosa/micro_services/attribute_generation.py
+++ b/src/satosa/micro_services/attribute_generation.py
@@ -129,7 +129,11 @@ you don't care which value is used in a template.
         for attr_name, values in attributes.items():
             context[attr_name] = MustachAttrValue(
                 attr_name,
-                values if values is not None else []
+                values
+                if values
+                and isinstance(values, list)
+                and all(isinstance(value, str) for value in values)
+                else [],
             )
 
         recipes = get_dict_defaults(self.synthetic_attributes, requester, provider)


### PR DESCRIPTION
When some attributes have different values then `None` or list of strings, this filter fails with an exception, even though it does not need these attributes. By adding this fix, the filter can be used when there are e.g. boolean attributes present (like `email_verified`).

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


