### PR TITLE
satosa.base: log state on debug level

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -207,7 +207,7 @@ class SATOSABase(object):
             context.state = state
             msg = "Loaded state {state} from cookie {cookie}".format(state=state, cookie=context.cookie)
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
-            logger.info(logline)
+            logger.debug(logline)
 
     def _save_state(self, resp, context):
         """


### PR DESCRIPTION
State of satosa can contain some encoded data (cookies_samesite_compat) which are to verbose on info level. Therefore The "Loaded state ..." log message is emitted on debug level.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


