### PR TITLE
Handle OIDC prompt together with SAML ForceAuthn and IsPassive

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -92,6 +92,7 @@ bind_password: !ENVFILE LDAP_BIND_PASSWORD_FILE
 | `FRONTEND_MODULES` | string[] | `[saml2_frontend.yaml, openid_connect_frontend.yaml]` | list of plugin configuration file paths, describing enabled frontends |
 | `MICRO_SERVICES` | string[] | `[statistics_service.yaml]` | list of plugin configuration file paths, describing enabled microservices |
 | `LOGGING` | dict | see [Python logging.conf](https://docs.python.org/3/library/logging.config.html) | optional configuration of application logging |
+| `PROMPT_TO_SAML_PARAM` | dict | `{"none":"is_passive","select_account":"force_authn","login":"force_authn"}` | mapping of OIDC prompt values to SAML authentication parameters |
 
 ## Attribute mapping configuration: `internal_attributes.yaml`
 

--- a/doc/internals/state.md
+++ b/doc/internals/state.md
@@ -40,3 +40,10 @@ If the account linking is enabled, the account linking module will save the foll
 * **ACCOUNT_LINKING.usr_id**: The id of the authenticated user
 * **ACCOUNT_LINKING.attr**: Contains all attributes and values given by the authentication
 * **ACCOUNT_LINKING.usr_id_attr**: An empty list
+
+### Authentication context class reference
+* **Context.KEY_AUTHN_CONTEXT_CLASS_REF**: ACR list requested by SP/client
+* **Context.KEY_TARGET_AUTHN_CONTEXT_CLASS_REF**: ACR list to be sent to backend
+
+ACR obtained from backend is available in `context.state.internal_resp.auth_info.auth_class_ref`.
+The time of this authentication is available in `context.state.internal_resp.auth_info.timestamp`.

--- a/src/satosa/backends/openid_connect.py
+++ b/src/satosa/backends/openid_connect.py
@@ -15,6 +15,7 @@ from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils.settings import PyoidcSettings
 
 import satosa.logging_util as lu
+from satosa.context import Context, get_auth_req_params
 from satosa.internal import AuthenticationInformation
 from satosa.internal import InternalData
 from .base import BackendModule
@@ -106,6 +107,7 @@ class OpenIDConnectBackend(BackendModule):
             "nonce": oidc_nonce
         }
         args.update(self.config["client"]["auth_req_params"])
+        args.update(get_auth_req_params(context))
         auth_req = self.client.construct_AuthorizationRequest(request_args=args)
         login_url = auth_req.request(self.client.authorization_endpoint)
         return Redirect(login_url)

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -23,7 +23,7 @@ import satosa.util as util
 from satosa.base import SAMLBaseModule
 from satosa.base import SAMLEIDASBaseModule
 from satosa.base import STATE_KEY as STATE_KEY_BASE
-from satosa.context import Context
+from satosa.context import Context, prompt_to_saml_param, get_prompt_list
 from satosa.internal import AuthenticationInformation
 from satosa.internal import InternalData
 from satosa.exception import SATOSAAuthenticationError
@@ -36,14 +36,14 @@ from satosa.metadata_creation.description import (
 )
 from satosa.backends.base import BackendModule
 
-
 logger = logging.getLogger(__name__)
 
 
 def get_memorized_idp(context, config, force_authn):
     memorized_idp = (
-        config.get(SAMLBackend.KEY_MEMORIZE_IDP)
-        and context.state.get(Context.KEY_MEMORIZED_IDP)
+            config.get(SAMLBackend.KEY_MEMORIZE_IDP)
+            and "select_account" not in get_prompt_list(context)
+            and context.state.get(Context.KEY_MEMORIZED_IDP)
     )
     use_when_force_authn = config.get(
         SAMLBackend.KEY_USE_MEMORIZED_IDP_WHEN_FORCE_AUTHN
@@ -52,27 +52,23 @@ def get_memorized_idp(context, config, force_authn):
     return value
 
 
-def get_force_authn(context, config, sp_config):
+def get_saml_param(context, config, sp_config, key):
     """
-    Return the force_authn value.
+    Return the value of ForceAuthn or IsPassive.
 
     The value comes from one of three place:
     - the configuration of the backend
     - the context, as it came through in the AuthnRequest handled by the frontend.
-      note: the frontend should have been set to mirror the force_authn value.
+      note: the frontend should have been set to mirror the value.
     - the cookie, as it has been stored by the proxy on a redirect to the DS
-      note: the frontend should have been set to mirror the force_authn value.
+      note: the frontend should have been set to mirror the value.
 
     The value is either "true" or None
     """
-    mirror = config.get(SAMLBackend.KEY_MIRROR_FORCE_AUTHN)
-    from_state = mirror and context.state.get(Context.KEY_FORCE_AUTHN)
-    from_context = (
-        mirror and context.get_decoration(Context.KEY_FORCE_AUTHN) in ["true", "1"]
-    )
-    from_config = sp_config.getattr("force_authn", "sp")
-    is_set = str(from_state or from_context or from_config).lower() == "true"
-    value = "true" if is_set else None
+    mirror = config.get("mirror_{}".format(key))
+    from_state_or_context = mirror and prompt_to_saml_param(context, key)
+    from_config = str(sp_config.getattr(key, "sp")).lower() == "true"
+    value = "true" if from_state_or_context or from_config else None
     return value
 
 
@@ -86,11 +82,12 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
     KEY_SP_CONFIG = 'sp_config'
     KEY_SEND_REQUESTER_ID = 'send_requester_id'
     KEY_MIRROR_FORCE_AUTHN = 'mirror_force_authn'
-    KEY_IS_PASSIVE = 'is_passive'
     KEY_MEMORIZE_IDP = 'memorize_idp'
     KEY_USE_MEMORIZED_IDP_WHEN_FORCE_AUTHN = 'use_memorized_idp_when_force_authn'
 
     VALUE_ACR_COMPARISON_DEFAULT = 'exact'
+
+    SAML_PARAMS = [Context.KEY_SAML_FORCE_AUTHN, Context.KEY_SAML_IS_PASSIVE]
 
     def __init__(self, outgoing, internal_attributes, config, base_url, name):
         """
@@ -154,23 +151,26 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         idps = self.sp.metadata.identity_providers()
         only_one_idp_in_metadata = (
-            "mdq" not in self.config["sp_config"]["metadata"]
-            and len(idps) == 1
+                "mdq" not in self.config["sp_config"]["metadata"]
+                and len(idps) == 1
         )
 
         only_idp = only_one_idp_in_metadata and idps[0]
         target_entity_id = context.get_decoration(Context.KEY_TARGET_ENTITYID)
-        force_authn = get_force_authn(context, self.config, self.sp.config)
-        memorized_idp = get_memorized_idp(context, self.config, force_authn)
+        saml_params = {
+            saml_param: get_saml_param(context, self.config, self.sp.config, saml_param)
+            for saml_param in SAMLBackend.SAML_PARAMS
+        }
+        memorized_idp = get_memorized_idp(context, self.config, saml_params["force_authn"])
         entity_id = only_idp or target_entity_id or memorized_idp or None
 
         msg = {
             "message": "Selected IdP",
             "only_one": only_idp,
             "target_entity_id": target_entity_id,
-            "force_authn": force_authn,
             "memorized_idp": memorized_idp,
             "entity_id": entity_id,
+            **saml_params
         }
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.info(logline)
@@ -189,9 +189,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         if entity_id is None:
             # since context is not passed to disco_query
             # keep the information in the state cookie
-            context.state[Context.KEY_FORCE_AUTHN] = get_force_authn(
-                context, self.config, self.sp.config
-            )
+            for saml_param in SAMLBackend.SAML_PARAMS:
+                context.state[saml_param] = get_saml_param(context, self.config, self.sp.config, saml_param)
             return self.disco_query(context)
 
         return self.authn_request(context, entity_id)
@@ -212,8 +211,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         return_url = endpoints["discovery_response"][0][0]
 
         disco_url = (
-            context.get_decoration(SAMLBackend.KEY_SAML_DISCOVERY_SERVICE_URL)
-            or self.discosrv
+                context.get_decoration(SAMLBackend.KEY_SAML_DISCOVERY_SERVICE_URL)
+                or self.discosrv
         )
         disco_policy = context.get_decoration(
             SAMLBackend.KEY_SAML_DISCOVERY_SERVICE_POLICY
@@ -238,8 +237,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
     def construct_requested_authn_context(self, entity_id, *, target_accr=None):
         acr_entry = (
-            target_accr
-            or util.get_dict_defaults(self.acr_mapping or {}, entity_id)
+                target_accr
+                or util.get_dict_defaults(self.acr_mapping or {}, entity_id)
         )
         if not acr_entry:
             return None
@@ -291,15 +290,12 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         authn_context = self.construct_requested_authn_context(entity_id, target_accr=target_accr)
         if authn_context:
             kwargs["requested_authn_context"] = authn_context
-        if self.config.get(SAMLBackend.KEY_MIRROR_FORCE_AUTHN):
-            kwargs["force_authn"] = get_force_authn(
-                context, self.config, self.sp.config
-            )
+        for saml_param in SAMLBackend.SAML_PARAMS:
+            if self.config.get(f"mirror_{saml_param}"):
+                kwargs[saml_param] = get_saml_param(context, self.config, self.sp.config, saml_param)
         if self.config.get(SAMLBackend.KEY_SEND_REQUESTER_ID):
             requester = context.state.state_dict[STATE_KEY_BASE]['requester']
             kwargs["scoping"] = Scoping(requester_id=[RequesterID(text=requester)])
-        if self.config.get(SAMLBackend.KEY_IS_PASSIVE):
-            kwargs["is_passive"] = "true"
 
         try:
             acs_endp, response_binding = self._get_acs(context)
@@ -468,7 +464,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         if self.config.get(SAMLBackend.KEY_MEMORIZE_IDP):
             issuer = authn_response.response.issuer.text.strip()
             context.state[Context.KEY_MEMORIZED_IDP] = issuer
-        context.state.pop(Context.KEY_FORCE_AUTHN, None)
+        for saml_param in SAMLBackend.SAML_PARAMS:
+            context.state.pop(saml_param, None)
         return self.auth_callback_func(context, self._translate_response(authn_response, context.state))
 
     def disco_response(self, context):

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -286,7 +286,8 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
                     raise SATOSAAuthenticationError(context.state, msg)
 
         kwargs = {}
-        target_accr = context.state.get(Context.KEY_TARGET_AUTHN_CONTEXT_CLASS_REF)
+        target_accr = context.state.get(Context.KEY_TARGET_AUTHN_CONTEXT_CLASS_REF)\
+            or context.get_decoration(Context.KEY_TARGET_AUTHN_CONTEXT_CLASS_REF)
         authn_context = self.construct_requested_authn_context(entity_id, target_accr=target_accr)
         if authn_context:
             kwargs["requested_authn_context"] = authn_context

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -127,6 +127,11 @@ class SATOSABase(object):
 
         # remove all session state unless CONTEXT_STATE_DELETE is False
         context.state.delete = self.config.get("CONTEXT_STATE_DELETE", True)
+        context.state.prompt_to_saml_param = self.config.get("PROMPT_TO_SAML_PARAM", {
+            "none":"is_passive",
+            "select_account":"force_authn",
+            "login":"force_authn",
+        })
         context.request = None
 
         frontend = self.module_router.frontend_routing(context)
@@ -407,3 +412,4 @@ class SAMLEIDASBaseModule(SAMLBaseModule):
         }
 
         return util.check_set_dict_defaults(config, spec_eidas)
+

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -3,17 +3,55 @@ from warnings import warn as _warn
 from satosa.exception import SATOSABadContextError
 
 
+def get_auth_req_params(context):
+    return context.state.get(Context.KEY_AUTH_REQ_PARAMS) or context.get_decoration(Context.KEY_AUTH_REQ_PARAMS) or {}
+
+
+def get_prompt_list(context):
+    auth_req_params = get_auth_req_params(context)
+    prompt = auth_req_params.get(Context.KEY_PROMPT, "")
+    return prompt if isinstance(prompt, list) else prompt.split(" ")
+
+
+def prompt_to_saml_param(context, saml_param):
+    prompt_list = get_prompt_list(context)
+    if saml_param == Context.KEY_SAML_IS_PASSIVE:
+        return "none" in prompt_list
+    # there is no standard way to force only account selection in SAML, force new login instead
+    if saml_param == Context.KEY_SAML_FORCE_AUTHN:
+        return "select_account" in prompt_list or "login" in prompt_list
+
+
+def add_prompt_to_context(context, prompt_value):
+    state_auth_req_params = context.state.get(Context.KEY_AUTH_REQ_PARAMS) or {}
+    context_auth_req_params = context.get_decoration(Context.KEY_AUTH_REQ_PARAMS) or {}
+    state_auth_req_params["prompt"] = prompt_value
+    context_auth_req_params["prompt"] = prompt_value
+    context.state[Context.KEY_AUTH_REQ_PARAMS] = state_auth_req_params
+    context.decorate(Context.KEY_AUTH_REQ_PARAMS, context_auth_req_params)
+
+
+def get_deprecated_context_key(old_key, new_key):
+    msg = "'{old_key}' is deprecated; use '{new_key}' instead.".format(
+        old_key=old_key, new_key=new_key
+    )
+    _warn(msg, DeprecationWarning)
+    return getattr(Context, new_key)
+
 class Context(object):
     """
     Holds methods for sharing proxy data through the current request
     """
     KEY_METADATA_STORE = 'metadata_store'
     KEY_TARGET_ENTITYID = 'target_entity_id'
-    KEY_FORCE_AUTHN = 'force_authn'
+    KEY_SAML_FORCE_AUTHN = 'force_authn'
+    KEY_SAML_IS_PASSIVE = 'is_passive'
     KEY_MEMORIZED_IDP = 'memorized_idp'
     KEY_REQUESTER_METADATA = 'requester_metadata'
     KEY_AUTHN_CONTEXT_CLASS_REF = 'authn_context_class_ref'
     KEY_TARGET_AUTHN_CONTEXT_CLASS_REF = 'target_authn_context_class_ref'
+    KEY_AUTH_REQ_PARAMS = 'auth_req_params'
+    KEY_PROMPT = 'prompt'
 
     def __init__(self):
         self._path = None
@@ -34,11 +72,7 @@ class Context(object):
 
     @property
     def KEY_BACKEND_METADATA_STORE(self):
-        msg = "'{old_key}' is deprecated; use '{new_key}' instead.".format(
-            old_key="KEY_BACKEND_METADATA_STORE", new_key="KEY_METADATA_STORE"
-        )
-        _warn(msg, DeprecationWarning)
-        return Context.KEY_METADATA_STORE
+        return get_deprecated_context_key("KEY_BACKEND_METADATA_STORE", "KEY_METADATA_STORE")
 
     @property
     def path(self):

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -15,12 +15,11 @@ def get_prompt_list(context):
 
 def prompt_to_saml_param(context, saml_param):
     prompt_list = get_prompt_list(context)
-    if saml_param == Context.KEY_SAML_IS_PASSIVE:
-        return "none" in prompt_list
-    # there is no standard way to force only account selection in SAML, force new login instead
-    if saml_param == Context.KEY_SAML_FORCE_AUTHN:
-        return "select_account" in prompt_list or "login" in prompt_list
-
+    prompt_mapping = context.state.get(Context.KEY_PROMPT_TO_SAML_PARAM)
+    for p, s in prompt_mapping.items():
+        if s == saml_param and p in prompt_list:
+            return True
+    return False
 
 def add_prompt_to_context(context, prompt_value):
     state_auth_req_params = context.state.get(Context.KEY_AUTH_REQ_PARAMS) or {}
@@ -54,6 +53,7 @@ class Context(object):
     KEY_TARGET_AUTHN_CONTEXT_CLASS_REF = 'target_authn_context_class_ref'
     KEY_AUTH_REQ_PARAMS = 'auth_req_params'
     KEY_PROMPT = 'prompt'
+    KEY_PROMPT_TO_SAML_PARAM = 'prompt_to_saml_param'
 
     def __init__(self):
         self._path = None

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -48,7 +48,9 @@ class Context(object):
     KEY_SAML_IS_PASSIVE = 'is_passive'
     KEY_MEMORIZED_IDP = 'memorized_idp'
     KEY_REQUESTER_METADATA = 'requester_metadata'
+    # ACR list requested by SP/client
     KEY_AUTHN_CONTEXT_CLASS_REF = 'authn_context_class_ref'
+    # ACR list to be sent to backend
     KEY_TARGET_AUTHN_CONTEXT_CLASS_REF = 'target_authn_context_class_ref'
     KEY_AUTH_REQ_PARAMS = 'auth_req_params'
     KEY_PROMPT = 'prompt'

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -28,7 +28,7 @@ from saml2.samlp import name_id_policy_from_string
 from saml2.server import Server
 
 from satosa.base import SAMLBaseModule
-from satosa.context import Context
+from satosa.context import Context, add_prompt_to_context
 from .base import FrontendModule
 from ..response import Response
 from ..response import ServiceError
@@ -223,8 +223,11 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
 
-        # keep the ForceAuthn value to be used by plugins
-        context.decorate(Context.KEY_FORCE_AUTHN, authn_req.force_authn)
+        # keep prompt-like values (ForceAuthn and IsPassive) to be used by plugins
+        if getattr(authn_req, Context.KEY_SAML_FORCE_AUTHN):
+            add_prompt_to_context(context, "login")
+        if getattr(authn_req, Context.KEY_SAML_IS_PASSIVE):
+            add_prompt_to_context(context, "none")
 
         try:
             resp_args = idp.response_args(authn_req)

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -224,9 +224,9 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         logger.debug(logline)
 
         # keep prompt-like values (ForceAuthn and IsPassive) to be used by plugins
-        if getattr(authn_req, Context.KEY_SAML_FORCE_AUTHN):
+        if getattr(authn_req, Context.KEY_SAML_FORCE_AUTHN) in ["1", "true"]:
             add_prompt_to_context(context, "login")
-        if getattr(authn_req, Context.KEY_SAML_IS_PASSIVE):
+        if getattr(authn_req, Context.KEY_SAML_IS_PASSIVE) in ["1", "true"]:
             add_prompt_to_context(context, "none")
 
         try:
@@ -1255,3 +1255,4 @@ class SAMLVirtualCoFrontend(SAMLFrontend):
         # authentication request dynamically create an IdP instance.
         self.idp = self._create_co_virtual_idp(context, co_name=co_name)
         return super()._metadata_endpoint(context=context);
+

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -286,6 +286,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         )
         authn_context = [ref.text for ref in authn_context_class_ref_nodes]
         context.decorate(Context.KEY_AUTHN_CONTEXT_CLASS_REF, authn_context)
+        context.state[Context.KEY_AUTHN_CONTEXT_CLASS_REF] = authn_context
         context.decorate(Context.KEY_METADATA_STORE, self.idp.metadata)
         return self.auth_req_callback_func(context, internal_req)
 

--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -450,7 +450,7 @@ class TestSAMLBackendRedirects:
         resp = samlbackend.start_auth(context, InternalData())
         assert_redirect_to_discovery_server(resp, sp_conf, DISCOSRV_URL)
 
-    def test_use_of_disco_or_redirect_to_idp_when_using_mdq_and_forceauthn_is_not_set(
+    def test_use_of_disco_or_redirect_to_idp_when_using_mdq_and_prompt_is_not_set(
         self, context, sp_conf, idp_conf
     ):
         sp_conf["metadata"]["inline"] = [create_metadata_from_config_dict(idp_conf)]
@@ -481,7 +481,7 @@ class TestSAMLBackendRedirects:
         resp = samlbackend.start_auth(context, InternalData())
         assert_redirect_to_discovery_server(resp, sp_conf, DISCOSRV_URL)
 
-        context.decorate(Context.KEY_FORCE_AUTHN, "0")
+        context.decorate(Context.KEY_AUTH_REQ_PARAMS, {})
         context.state[Context.KEY_MEMORIZED_IDP] = idp_conf["entityid"]
         backend_conf[SAMLBackend.KEY_USE_MEMORIZED_IDP_WHEN_FORCE_AUTHN] = True
         samlbackend = SAMLBackend(
@@ -490,48 +490,20 @@ class TestSAMLBackendRedirects:
         resp = samlbackend.start_auth(context, InternalData())
         assert_redirect_to_discovery_server(resp, sp_conf, DISCOSRV_URL)
 
-    def test_use_of_disco_or_redirect_to_idp_when_using_mdq_and_forceauthn_is_set_true(
+    def test_use_of_disco_or_redirect_to_idp_when_using_mdq_and_prompt_is_set_login(
         self, context, sp_conf, idp_conf
     ):
         sp_conf["metadata"]["inline"] = [create_metadata_from_config_dict(idp_conf)]
         sp_conf["metadata"]["mdq"] = ["https://mdq.example.com"]
 
-        context.decorate(Context.KEY_FORCE_AUTHN, "true")
+        context.decorate(Context.KEY_AUTH_REQ_PARAMS, {"prompt": "login"})
         context.state[Context.KEY_MEMORIZED_IDP] = idp_conf["entityid"]
 
         backend_conf = {
             SAMLBackend.KEY_SP_CONFIG: sp_conf,
             SAMLBackend.KEY_DISCO_SRV: DISCOSRV_URL,
             SAMLBackend.KEY_MEMORIZE_IDP: True,
-            SAMLBackend.KEY_MIRROR_FORCE_AUTHN: True,
-        }
-        samlbackend = SAMLBackend(
-            None, INTERNAL_ATTRIBUTES, backend_conf, "base_url", "saml_backend"
-        )
-        resp = samlbackend.start_auth(context, InternalData())
-        assert_redirect_to_discovery_server(resp, sp_conf, DISCOSRV_URL)
-
-        backend_conf[SAMLBackend.KEY_USE_MEMORIZED_IDP_WHEN_FORCE_AUTHN] = True
-        samlbackend = SAMLBackend(
-            None, INTERNAL_ATTRIBUTES, backend_conf, "base_url", "saml_backend"
-        )
-        resp = samlbackend.start_auth(context, InternalData())
-        assert_redirect_to_idp(resp, idp_conf)
-
-    def test_use_of_disco_or_redirect_to_idp_when_using_mdq_and_forceauthn_is_set_1(
-        self, context, sp_conf, idp_conf
-    ):
-        sp_conf["metadata"]["inline"] = [create_metadata_from_config_dict(idp_conf)]
-        sp_conf["metadata"]["mdq"] = ["https://mdq.example.com"]
-
-        context.decorate(Context.KEY_FORCE_AUTHN, "1")
-        context.state[Context.KEY_MEMORIZED_IDP] = idp_conf["entityid"]
-
-        backend_conf = {
-            SAMLBackend.KEY_SP_CONFIG: sp_conf,
-            SAMLBackend.KEY_DISCO_SRV: DISCOSRV_URL,
-            SAMLBackend.KEY_MEMORIZE_IDP: True,
-            SAMLBackend.KEY_MIRROR_FORCE_AUTHN: True,
+            'mirror_force_authn': True,
         }
         samlbackend = SAMLBackend(
             None, INTERNAL_ATTRIBUTES, backend_conf, "base_url", "saml_backend"


### PR DESCRIPTION
Allow processing prompt=none/login/select_account/consent, ForceAuthn=true and IsPassive=true, including interoperability (e.g. IsPassive=true from SAML frontend is converted to prompt=none in OIDC backend)

Change is backward compatible considering nobody is using `prompt` and `IsPassive` on frontends or the constant `Context.KEY_FORCE_AUTHN`.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
  * Changes are covered by modified existing tests
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
  * yes, but there were many violations already
