### PR TITLE
fix: OpenIDConnectFrontend: check for empty db_uri

### DIFF
--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -72,7 +72,7 @@ class OpenIDConnectFrontend(FrontendModule):
         )
 
         db_uri = self.config.get("db_uri")
-        self.stateless = StorageBase.type(db_uri) == "stateless"
+        self.stateless = db_uri and StorageBase.type(db_uri) == "stateless"
         self.user_db = (
             StorageBase.from_uri(db_uri, db_name="satosa", collection="authz_codes")
             if db_uri and not self.stateless


### PR DESCRIPTION
With IdentityPython/pyop#44 merged, OpenIDConnectFrontend init fails when `db_uri` is not set, as `StorageBase.type` now throws a `ValueError` for db_uri values that do not match one of the recognised storage types (including when `db_uri` is `None`).

Fix this by guarding the `StorageBase.type` with a pythonic test whether `db_uri` was provided.

Same test already guards `StorageBase.from_uri`, add it also to the `StorageBase.type` call made to determine `self.stateless`.

PS: This worked before IdentityPython/pyop#44 was merged because `StorageBase.type` used to _return_  the `ValueError` object, which evaluated as not matching string `"stateless"`.  I also thought about changing `StorageBase.type` to return `None` for `db_uri` of value `None`, but I think it's cleaner to handle it this way and keep the `StorageBase.type` contract clear: Only valid values allowed.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [N/A] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [N/A] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


