### PR TITLE
Deny auth if requested attribute is missing

### DIFF
--- a/src/satosa/micro_services/attribute_authorization.py
+++ b/src/satosa/micro_services/attribute_authorization.py
@@ -53,6 +53,9 @@ structure above) are ORed together - i.e any attribute match is sufficient.
             if attribute_name in attributes:
                 if not any([any(filter(re.compile(af).search, attributes[attribute_name])) for af in attribute_filters]):
                     raise SATOSAAuthenticationError(context.state, "Permission denied")
+            else:
+                raise SATOSAAuthenticationError(context.state, "Permission denied")
+
 
         for attribute_name, attribute_filters in get_dict_defaults(self.attribute_deny, requester, provider).items():
             if attribute_name in attributes:

--- a/tests/satosa/micro_services/test_attribute_authorization.py
+++ b/tests/satosa/micro_services/test_attribute_authorization.py
@@ -44,6 +44,20 @@ class TestAttributeAuthorization:
            ctx.state = dict()
            authz_service.process(ctx, resp)
 
+    def test_authz_allow_missing(self):
+        attribute_allow = {
+           "": { "default": {"a0": ['foo1','foo2']} }
+        }
+        attribute_deny = {}
+        authz_service = self.create_authz_service(attribute_allow, attribute_deny)
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {
+        }
+        with pytest.raises(SATOSAAuthenticationError):
+           ctx = Context()
+           ctx.state = dict()
+           authz_service.process(ctx, resp)
+
     def test_authz_allow_second(self):
         attribute_allow = {
            "": { "default": {"a0": ['foo1','foo2']} }


### PR DESCRIPTION
If a requested attribute is missing the authorization should fail

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


