### PR TITLE
DecideBackendByRequester: add default_backend setting

### DIFF
--- a/example/plugins/microservices/custom_routing_decide_by_requester.yaml.example
+++ b/example/plugins/microservices/custom_routing_decide_by_requester.yaml.example
@@ -1,6 +1,7 @@
 module: satosa.micro_services.custom_routing.DecideBackendByRequester
 name: DecideBackendByRequester
 config:
+  default_backend: Saml2
   requester_mapping:
      'requestor-id': 'backend_custom'
 

--- a/example/plugins/microservices/custom_routing_decide_by_requester.yaml.example
+++ b/example/plugins/microservices/custom_routing_decide_by_requester.yaml.example
@@ -1,0 +1,7 @@
+module: satosa.micro_services.custom_routing.DecideBackendByRequester
+name: DecideBackendByRequester
+config:
+  requester_mapping:
+     'requestor-id': 'backend_custom'
+
+

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -79,7 +79,7 @@ class DecideBackendByRequester(RequestMicroService):
         :param context: request context
         :param data: the internal request
         """
-        context.target_backend = self.requester_mapping[data.requester]
+        context.target_backend = self.requester_mapping.get(data.requester)
         return super().process(context, data)
 
 

--- a/src/satosa/micro_services/custom_routing.py
+++ b/src/satosa/micro_services/custom_routing.py
@@ -67,11 +67,13 @@ class DecideBackendByRequester(RequestMicroService):
         """
         Constructor.
         :param config: mapping from requester identifier to
-        backend module name under the key 'requester_mapping'
+        backend module name under the key 'requester_mapping'.
+        May also include default backend under key 'default_backend'.
         :type config: Dict[str, Dict[str, str]]
         """
         super().__init__(*args, **kwargs)
         self.requester_mapping = config['requester_mapping']
+        self.default_backend = config.get('default_backend')
 
     def process(self, context, data):
         """
@@ -79,7 +81,7 @@ class DecideBackendByRequester(RequestMicroService):
         :param context: request context
         :param data: the internal request
         """
-        context.target_backend = self.requester_mapping.get(data.requester)
+        context.target_backend = self.requester_mapping.get(data.requester) or self.default_backend
         return super().process(context, data)
 
 

--- a/tests/satosa/micro_services/test_custom_routing.py
+++ b/tests/satosa/micro_services/test_custom_routing.py
@@ -227,10 +227,24 @@ class TestDecideBackendByRequester(TestCase):
         self.context = context
         self.plugin = plugin
 
-    def test_when_requester_is_not_mapped_skip(self):
+    def test_when_requester_is_not_mapped_and_no_default_backend_skip(self):
         data = InternalData(requester='other_test_requester')
         newctx, newdata = self.plugin.process(self.context, data)
         assert not newctx.target_backend
+
+    def test_when_requester_is_not_mapped_choose_default_backend(self):
+        # override config to set default backend
+        self.config['default_backend'] = 'default_backend'
+        self.plugin = DecideBackendByRequester(
+            config=self.config,
+            name='test_decide_service',
+            base_url='https://satosa.example.org',
+        )
+        self.plugin.next = lambda ctx, data: (ctx, data)
+
+        data = InternalData(requester='other_test_requester')
+        newctx, newdata = self.plugin.process(self.context, data)
+        assert newctx.target_backend == 'default_backend'
 
     def test_when_requester_is_mapped_choose_mapping_backend(self):
         data = InternalData(requester='test_requester')


### PR DESCRIPTION
Enhance the `DecideBackendByRequester` microservice: support a `default_backend` setting - to avoid having to spell out all requesters: with default backend.  With a default backend, only exceptions/overrides need to be listed.

Also add missing tests for `DecideBackendByRequester` - and then add tests covering this feature.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests? (new functionality passes)
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


