### PR TITLE
Introduce SAML SP-initiated Logout to SATOSA proxy

### DIFF
--- a/src/satosa/backends/base.py
+++ b/src/satosa/backends/base.py
@@ -10,10 +10,11 @@ class BackendModule(object):
     Base class for a backend module.
     """
 
-    def __init__(self, auth_callback_func, internal_attributes, base_url, name):
+    def __init__(self, auth_callback_func, logout_callback_func, internal_attributes, base_url, name):
         """
         :type auth_callback_func:
         (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
+        :type logout_callback_func:
         :type internal_attributes: dict[string, dict[str, str | list[str]]]
         :type base_url: str
         :type name: str
@@ -27,6 +28,7 @@ class BackendModule(object):
         :param name: name of the plugin
         """
         self.auth_callback_func = auth_callback_func
+        self.logout_callback_func = logout_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
         self.base_url = base_url

--- a/src/satosa/backends/base.py
+++ b/src/satosa/backends/base.py
@@ -48,6 +48,20 @@ class BackendModule(object):
         """
         raise NotImplementedError()
 
+    def start_logout(self, context, internal_request):
+        """
+        This is the start up function of the backend logout.
+
+        :type context: satosa.context.Context
+        :type internal_request: satosa.internal.InternalData
+        :rtype
+
+        :param context: the request context
+        :param internal_request: Information about the logout request
+        :return:
+        """
+        raise NotImplementedError()
+
     def register_endpoints(self):
         """
         Register backend functions to endpoint urls.

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -197,7 +197,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         return self.authn_request(context, entity_id)
 
-    def start_logout(self, context, internal_req):
+    def start_logout(self, context, internal_req, internal_authn_resp):
         """
         See super class method satosa.backends.base.BackendModule#start_logout
 
@@ -207,7 +207,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         """
 
         entity_id = self.get_idp_entity_id(context)
-        return self.logout_request(context, entity_id)
+        return self.logout_request(context, entity_id, internal_authn_resp)
 
     def disco_query(self, context):
         """
@@ -378,7 +378,7 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         context.state.pop(Context.KEY_FORCE_AUTHN, None)
         return self.auth_callback_func(context, self._translate_response(authn_response, context.state))
 
-    def logout_request(self, context, entity_id):
+    def logout_request(self, context, entity_id, internal_authn_resp):
         """
         Perform Logout request on idp with given entity_id.
         This is the start of single logout.
@@ -401,9 +401,12 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
             slo_endp, response_binding = self.sp.config.getattr("endpoints", "sp")["single_logout_service"][0]
             name_id_format = self.sp.config.getattr("name_id_format", "sp")
-            name_id = NameID(format=name_id_format)
+            name_id = internal_authn_resp["subject_id"]
+            name_id = NameID(format=name_id_format, text=name_id)
+            session_indexes = internal_authn_resp["auth_info"]["session_index"]
             req_id, req = self.sp.create_logout_request(
-                destination, issuer_entity_id=entity_id, name_id=name_id
+                destination, issuer_entity_id=entity_id, name_id=name_id,
+                session_indexes=session_indexes, sign=True
             )
             msg = "req_id: {}, req: {}".format(req_id, req)
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
@@ -467,13 +470,14 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             if authenticating_authorities
             else None
         )
-        session_index = response.session_info()['session_index']
+        session_indexes = []
+        session_indexes.append(response.session_info()['session_index'])
         auth_info = AuthenticationInformation(
             auth_class_ref=authn_context_ref,
             timestamp=authn_instant,
             authority=authenticating_authority,
             issuer=issuer,
-            session_index=session_index,
+            session_index=session_indexes,
         )
 
         # The SAML response may not include a NameID.

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -450,10 +450,9 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
             logger.debug(logline, exc_info=True)
             raise SATOSAUnknownError(context.state, "Failed to parse logout response") from err
-
-        return self.logout_callback_func(context, self._translate_logout_response(
-            logout_response, context.state))
-
+        message = "Logout {}".format("OK" if logout_response else "Failed")
+        status = "200 OK" if logout_response else "500 FAILED"
+        return Response(message=message, status=status)
 
     def disco_response(self, context):
         """

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -89,10 +89,11 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
     VALUE_ACR_COMPARISON_DEFAULT = 'exact'
 
-    def __init__(self, outgoing, internal_attributes, config, base_url, name):
+    def __init__(self, outgoing, logout, internal_attributes, config, base_url, name):
         """
         :type outgoing:
         (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
+        :type logout:
         :type internal_attributes: dict[str, dict[str, list[str] | str]]
         :type config: dict[str, Any]
         :type base_url: str
@@ -100,12 +101,13 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
 
         :param outgoing: Callback should be called by the module after
                                    the authorization in the backend is done.
+        :param logout: Logout callback
         :param internal_attributes: Internal attribute map
         :param config: The module config
         :param base_url: base url of the service
         :param name: name of the plugin
         """
-        super().__init__(outgoing, internal_attributes, base_url, name)
+        super().__init__(outgoing, logout, internal_attributes, base_url, name)
         self.config = self.init_config(config)
 
         self.discosrv = config.get(SAMLBackend.KEY_DISCO_SRV)

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -26,6 +26,7 @@ from satosa.base import SAMLEIDASBaseModule
 from satosa.base import STATE_KEY as STATE_KEY_BASE
 from satosa.context import Context
 from satosa.internal import AuthenticationInformation
+from satosa.internal import LogoutInformation
 from satosa.internal import InternalData
 from satosa.exception import SATOSAAuthenticationError
 from satosa.exception import SATOSAUnknownError
@@ -435,7 +436,23 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         :param binding: SAML binding type
         :return Response
         """
-        raise NotImplementedError()
+        if not context.request.get("SAMLResponse"):
+            msg = "Missing Response for state"
+            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+            logger.debug(logline)
+            raise SATOSAUnknownError(context.state, "Missing Response")
+
+        try:
+            logout_response = self.sp.parse_logout_request_response(
+                    context.request["SAMLResponse"], binding)
+        except Exception as err:
+            msg = "Failed to parse logout response for state"
+            logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+            logger.debug(logline, exc_info=True)
+            raise SATOSAUnknownError(context.state, "Failed to parse logout response") from err
+
+        return self.logout_callback_func(context, self._translate_logout_response(
+            logout_response, context.state))
 
 
     def disco_response(self, context):
@@ -517,6 +534,25 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         logline = lu.LOG_FMT.format(id=lu.get_session_id(state), message=msg)
         logger.debug(logline)
         return internal_resp
+
+    def _translate_logout_response(self, response, state):
+        timestamp = response.response.issue_instant
+        issuer = response.response.issuer.text
+
+        status = {
+            "status_code": response.response.status.status_code.value,
+        }
+
+        logout_info = LogoutInformation(
+            timestamp=timestamp,
+            issuer=issuer,
+            status=status
+        )
+
+        msg = "logout response content"
+        logline = lu.LOG_FMT.format(id=lu.get_session_id(state), message=msg)
+        logger.debug(logline)
+        return logout_info
 
     def _metadata_endpoint(self, context):
         """

--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -423,6 +423,21 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
             raise SATOSAUnknownError
         return make_saml_response(binding, ht_args)
 
+    def logout_response(self, context, binding):
+        """
+        Endpoint for the idp logout response
+
+        :type context: satosa.context.Context
+        :type binding: str
+        :rtype: satosa.response.Response
+
+        :param context: The current context
+        :param binding: SAML binding type
+        :return Response
+        """
+        raise NotImplementedError()
+
+
     def disco_response(self, context):
         """
         Endpoint for the discovery server response
@@ -560,6 +575,11 @@ class SAMLBackend(BackendModule, SAMLBaseModule):
         if self.enable_metadata_reload():
             url_map.append(
                 ("^%s/%s$" % (self.name, "reload-metadata"), self._reload_metadata))
+
+        for endp, binding in sp_endpoints["single_logout_service"]:
+            parsed_endp = urlparse(endp)
+            url_map.append(("^%s$" % parsed_endp.path[1:],
+                functools.partial(self.logout_response, binding=binding)))
 
         return url_map
 

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -105,12 +105,33 @@ class SATOSABase(object):
         return self._auth_req_finish(context, internal_request)
 
     def _logout_req_callback_func(self, context, internal_request):
-        raise NotImplementedError()
+        """
+        This function is called by a frontend module when a logout request has been processed.
+
+        :type context: satosa.context.Context
+        :typr internal_request:
+        :rtype:
+
+        :param context: The request context
+        :param internal_request: request processed by the frontend
+        :return Response
+        """
+        state = context.state
+        state[STATE_KEY] = {"requester": internal_request.requester}
+        msg = "Requesting provider: {}".format(internal_request.requester)
+        logline = lu.LOG_FMT.format(id=lu.get_session_id(state), message=msg)
+        logger.info(logline)
+        return self._logout_req_finish(context, internal_request)
 
     def _auth_req_finish(self, context, internal_request):
         backend = self.module_router.backend_routing(context)
         context.request = None
         return backend.start_auth(context, internal_request)
+
+    def _logout_req_finish(self, context, internal_request):
+        backend = self.module_router.backend_routing(context)
+        context.request = None
+        return backend.start_logout(context, internal_request)
 
     def _auth_resp_finish(self, context, internal_response):
         user_id_to_attr = self.config["INTERNAL_ATTRIBUTES"].get("user_id_to_attr", None)

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -41,9 +41,11 @@ class SATOSABase(object):
 
         logger.info("Loading backend modules...")
         backends = load_backends(self.config, self._auth_resp_callback_func,
+                                 self._logout_resp_callback_func,
                                  self.config["INTERNAL_ATTRIBUTES"])
         logger.info("Loading frontend modules...")
         frontends = load_frontends(self.config, self._auth_req_callback_func,
+                                   self._logout_req_callback_func,
                                    self.config["INTERNAL_ATTRIBUTES"])
 
         self.response_micro_services = []
@@ -102,6 +104,9 @@ class SATOSABase(object):
 
         return self._auth_req_finish(context, internal_request)
 
+    def _logout_req_callback_func(self, context, internal_request):
+        raise NotImplementedError()
+
     def _auth_req_finish(self, context, internal_request):
         backend = self.module_router.backend_routing(context)
         context.request = None
@@ -149,6 +154,9 @@ class SATOSABase(object):
                 context, internal_response)
 
         return self._auth_resp_finish(context, internal_response)
+
+    def _logout_resp_callback_func(self, context, internal_response):
+        raise NotImplementedError()
 
     def _handle_satosa_authentication_error(self, error):
         """

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -13,6 +13,7 @@ from .exception import SATOSAConfigurationError
 from .exception import SATOSAError, SATOSAAuthenticationError, SATOSAUnknownError
 from .plugin_loader import load_backends, load_frontends
 from .plugin_loader import load_request_microservices, load_response_microservices
+from .plugin_loader import load_database
 from .routing import ModuleRouter, SATOSANoBoundEndpointError
 from .state import cookie_to_state, SATOSAStateError, State, state_to_cookie
 
@@ -65,6 +66,9 @@ class SATOSABase(object):
                                             self.config["INTERNAL_ATTRIBUTES"],
                                             self.config["BASE"]))
             self._link_micro_services(self.response_micro_services, self._auth_resp_finish)
+
+        logger.info("Loading database...")
+        self.db = load_database(self.config)
 
         self.module_router = ModuleRouter(frontends, backends,
                                           self.request_micro_services + self.response_micro_services)

--- a/src/satosa/frontends/base.py
+++ b/src/satosa/frontends/base.py
@@ -9,7 +9,7 @@ class FrontendModule(object):
     Base class for a frontend module.
     """
 
-    def __init__(self, auth_req_callback_func, internal_attributes, base_url, name):
+    def __init__(self, auth_req_callback_func, logout_req_callback_func, internal_attributes, base_url, name):
         """
         :type auth_req_callback_func:
         (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
@@ -21,6 +21,7 @@ class FrontendModule(object):
         :param name: name of the plugin
         """
         self.auth_req_callback_func = auth_req_callback_func
+        self.logout_req_callback_func = logout_req_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
         self.base_url = base_url

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -164,6 +164,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         # Create the idp
         idp_config = IdPConfig().load(copy.deepcopy(self.idp_config))
         self.idp = Server(config=idp_config)
+        self.sp_sessions = {}
         return self._register_endpoints(backend_names) + url_map
 
     def _create_state_data(self, context, resp_args, relay_state):
@@ -339,6 +340,29 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             requester=requester,
         )
 
+        sp_sessions = self._sp_session_info(context)
+
+        for sp_info in sp_sessions:
+            for authn_statement in sp_info[1]:
+                if authn_statement[0].session_index == resp_args["session_indexes"][0]:
+                    continue
+                else:
+                    binding, slo_destination = self.idp.pick_binding(
+                        "single_logout_service", None, "spsso", entity_id=sp_info[0][0]
+                    )
+
+                    lreq_id, lreq = self.idp.create_logout_request(
+                        destination=slo_destination,
+                        issuer_entity_id=sp_info[0][0],
+                        name_id=NameID(text=sp_info[0][1].text),
+                        session_indexes=[authn_statement[0].session_index]
+                    )
+
+                    http_args = self.idp.apply_binding(binding, "%s" % lreq, slo_destination)
+                    msg = "http_args: {}".format(http_args)
+                    logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
+                    make_saml_response(binding, http_args)
+
         # Return logout response to SP that initiated logout if logout request contains
         # the <aslo:Asynchronous> element within the <samlp:Extensions> element
         extensions = logout_req.extensions if logout_req.extensions else None
@@ -358,6 +382,22 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
 
         return self.logout_req_callback_func(context, internal_req)
 
+    def _sp_session_info(self, context):
+        """
+        :type context: satosa.context.Context
+        :rtype: list[((str, saml2.saml.NameID), [[saml2.saml.AuthnStatement]])]
+
+        :param context: The current context
+        :return: list of service provider session information
+        """
+        sp_sessions = []
+
+        session_id = context.state["SESSION_ID"]
+        if session_id in self.sp_sessions:
+            for sp in self.sp_sessions[session_id]:
+                sp_sessions.append(
+                    (sp, self.idp.session_db.get_authn_statements(sp[1])))
+            return sp_sessions
 
     def _get_approved_attributes(self, idp, idp_policy, sp_entity_id, state):
         """
@@ -461,6 +501,12 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
             sp_name_qualifier=None,
             name_qualifier=None,
         )
+
+        session_id = context.state["SESSION_ID"]
+        if session_id not in self.sp_sessions.keys():
+            self.sp_sessions[session_id] = []
+
+        self.sp_sessions[session_id].append((sp_entity_id, name_id))
 
         msg = "returning attributes {}".format(json.dumps(ava))
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -99,6 +99,25 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         """
         return self._handle_authn_request(context, binding_in, self.idp)
 
+    def handle_logout_message(self, context, binding_in):
+        """
+        This method is bound to the starting endpoint of the logout.
+
+        :type context: satosa.context.Context
+        :type binding_in: str
+        :rtype:
+
+        :param context: The current context
+        :param binding_in: The binding type
+        :return:
+        """
+        if context.request["SAMLRequest"]:
+            return self.handle_logout_request(context, binding_in)
+        elif context.request["SAMLResponse"]:
+            return self.handle_logout_logout_response(context, binding_in)
+        else:
+            return NotImplementedError()
+
     def handle_logout_request(self, context, binding_in):
         """
         This method is bound to the starting endpoint of the logout.
@@ -111,6 +130,9 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         :return: response
         """
         return self._handle_logout_request(context, binding_in, self.idp)
+
+    def handle_logout_logout_response(self, context, binding_in):
+        return NotImplementedError()
 
     def handle_backend_error(self, exception):
         """
@@ -577,7 +599,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
                                     functools.partial(self.handle_authn_request, binding_in=binding)))
                 elif endp_category == "single_logout_service":
                     url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
-                                    functools.partial(self.handle_logout_request, binding_in=binding)))
+                                    functools.partial(self.handle_logout_message, binding_in=binding)))
                 else:
                     raise NotImplementedError()
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -65,10 +65,10 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
     KEY_ENDPOINTS = 'endpoints'
     KEY_IDP_CONFIG = 'idp_config'
 
-    def __init__(self, auth_req_callback_func, internal_attributes, config, base_url, name):
+    def __init__(self, auth_req_callback_func, logout_req_callback_func, internal_attributes, config, base_url, name):
         self._validate_config(config)
 
-        super().__init__(auth_req_callback_func, internal_attributes, base_url, name)
+        super().__init__(auth_req_callback_func, logout_req_callback_func, internal_attributes, base_url, name)
         self.config = self.init_config(config)
 
         self.endpoints = config[self.KEY_ENDPOINTS]

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -291,7 +291,26 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         msg = "{}".format(logout_req)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
-        internal_req = InternalData()
+
+        resp_args = {}
+        resp_args['name_id'] = logout_req.name_id.text if logout_req.name_id.text else None
+        resp_args['session_indexes'] = []
+        for session_index in logout_req.session_index:
+            resp_args['session_indexes'].append(session_index.text)
+        requester = logout_req.issuer.text
+        requester_name = self._get_sp_display_name(idp, requester)
+
+        context.state[self.name] = self._create_state_data(context, resp_args,
+                                                        context.request.get("RelayState"))
+
+        name_id_value = logout_req.name_id.text
+        name_id_format = logout_req.name_id.format
+
+        internal_req = InternalData(
+            subject_id=name_id_value,
+            subject_type=name_id_format,
+            requester=requester,
+        )
         return self.logout_req_callback_func(context, internal_req)
 
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -114,7 +114,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         if context.request["SAMLRequest"]:
             return self.handle_logout_request(context, binding_in)
         elif context.request["SAMLResponse"]:
-            return self.handle_logout_logout_response(context, binding_in)
+            return self.handle_logout_response(context, binding_in)
         else:
             return NotImplementedError()
 
@@ -131,8 +131,13 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         """
         return self._handle_logout_request(context, binding_in, self.idp)
 
-    def handle_logout_logout_response(self, context, binding_in):
-        return NotImplementedError()
+    def handle_logout_response(self, context, binding_in):
+        """
+        See super class method satosa.frontends.base.FrontendModule#handle_logout_response
+        :type context: satosa.context.Context
+        :type binding_in: str
+        """
+        return self._handle_logout_response(context, binding_in, self.idp)
 
     def handle_backend_error(self, exception):
         """
@@ -522,6 +527,19 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
 
         del context.state[self.name]
         return make_saml_response(resp_args["binding"], http_args)
+
+    def _handle_logout_response(self, context, internal_response, idp):
+        """
+        See super class method satosa.frontends.base.FrontendModule#handle_logout_response
+        :type context: satosa.context.Context
+        :type internal_response: satosa.internal.InternalData
+        :rtype satosa.response.LogoutResponse
+
+        :param context: the current context
+        :param internal_response: the internal logout response
+        :param idp: the saml frontend idp
+        """
+        return NotImplementedError()
 
     def _handle_backend_error(self, exception, idp):
         """

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -99,6 +99,19 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         """
         return self._handle_authn_request(context, binding_in, self.idp)
 
+    def handle_logout_request(self, context, binding_in):
+        """
+        This method is bound to the starting endpoint of the logout.
+
+        :type context: satosa.context.Context
+        :type binding_in: str
+
+        :param contxt: The current context
+        :param binding_in: The binding type (http post, http redirect, ..)
+        :return: response
+        """
+        return NotImplementedError()
+
     def handle_backend_error(self, exception):
         """
         See super class satosa.frontends.base.FrontendModule
@@ -519,8 +532,14 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
                     valid_providers = "{}|^{}".format(valid_providers, provider)
                 valid_providers = valid_providers.lstrip("|")
                 parsed_endp = urlparse(endp)
-                url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
-                                functools.partial(self.handle_authn_request, binding_in=binding)))
+                if endp_category == "single_sign_on_service":
+                    url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
+                                    functools.partial(self.handle_authn_request, binding_in=binding)))
+                elif endp_category == "single_logout_service":
+                    url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
+                                    functools.partial(self.handle_logout_request, binding_in=binding)))
+                else:
+                    raise NotImplementedError()
 
         if self.expose_entityid_endpoint():
             logger.debug("Exposing frontend entity endpoint = {}".format(self.idp.config.entityid))

--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -111,6 +111,30 @@ class AuthenticationInformation(_Datafy):
         self.authority = authority
 
 
+class LogoutInformation(_Datafy):
+    """
+    Class that holds information about the logout
+    """
+
+    def __init__(
+        self,
+        timestamp=None,
+        issuer=None,
+        status=None,
+        *args,
+        **kwargs,
+    ):
+        """
+        :param timestamp: time when the logout was done
+        :param issuer: where the logout was done
+        :param status: status of the logout
+        """
+        super().__init__(self, *args, **kwargs)
+        self.timestamp = timestamp
+        self.issuer = issuer
+        self.status = status
+
+
 class InternalData(_Datafy):
     """
     A base class for the data carriers between frontends/backends

--- a/src/satosa/metadata_creation/saml_metadata.py
+++ b/src/satosa/metadata_creation/saml_metadata.py
@@ -104,8 +104,8 @@ def create_entity_descriptors(satosa_config):
     :type satosa_config: satosa.satosa_config.SATOSAConfig
     :rtype: Tuple[str, str]
     """
-    frontend_modules = load_frontends(satosa_config, None, satosa_config["INTERNAL_ATTRIBUTES"])
-    backend_modules = load_backends(satosa_config, None, satosa_config["INTERNAL_ATTRIBUTES"])
+    frontend_modules = load_frontends(satosa_config, None, None, satosa_config["INTERNAL_ATTRIBUTES"])
+    backend_modules = load_backends(satosa_config, None, None, satosa_config["INTERNAL_ATTRIBUTES"])
     logger.info("Loaded frontend plugins: {}".format([frontend.name for frontend in frontend_modules]))
     logger.info("Loaded backend plugins: {}".format([backend.name for backend in backend_modules]))
 

--- a/src/satosa/plugin_loader.py
+++ b/src/satosa/plugin_loader.py
@@ -289,3 +289,31 @@ def load_response_microservices(plugin_path, plugins, internal_attributes, base_
                                             base_url)
     logger.info("Loaded response micro services:{}".format([type(k).__name__ for k in response_services]))
     return response_services
+
+
+def load_database(config):
+    """
+    Loads the storage database specifies in the config
+
+    :type config: satosa.satosa_config.SATOSAConfig
+
+    :param config: The configuration of the satosa proxy
+    """
+    try:
+        db = config["DATABASE"]["name"]
+    except SATOSAConfigurationError as err:
+        logger.error(err)
+    if db == "memory":
+        from satosa.store import SessionStorage
+        return SessionStorage(config)
+    elif db == "mongodb":
+        from satosa.store import SessionStorageMDB
+        return SessionStorageMDB(config)
+    elif db == "postgresql":
+        from satosa.store import SessionStoragePDB
+        try:
+            return SessionStoragePDB(config)
+        except Exception as error:
+            return error
+    else:
+        raise NotImplementedError()

--- a/src/satosa/plugin_loader.py
+++ b/src/satosa/plugin_loader.py
@@ -27,46 +27,55 @@ def prepend_to_import_path(import_paths):
     del sys.path[0:len(import_paths)]  # restore sys.path
 
 
-def load_backends(config, callback, internal_attributes):
+def load_backends(config, auth_callback, logout_callback, internal_attributes):
     """
     Load all backend modules specified in the config
 
     :type config: satosa.satosa_config.SATOSAConfig
-    :type callback:
+    :type auth_callback:
+    (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
+    :type logout_callback:
     (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
     :type internal_attributes: dict[string, dict[str, str | list[str]]]
     :rtype: Sequence[satosa.backends.base.BackendModule]
 
     :param config: The configuration of the satosa proxy
-    :param callback: Function that will be called by the backend after the authentication is done.
+    :param auth_callback: Function that will be called by the backend after the authentication is done.
+    :param logout_callback: Function that will be called by the backend after logout is done.
     :return: A list of backend modules
     """
     backend_modules = _load_plugins(
         config.get("CUSTOM_PLUGIN_MODULE_PATHS"),
         config["BACKEND_MODULES"],
         backend_filter, config["BASE"],
-        internal_attributes, callback)
+        internal_attributes, auth_callback,
+        logout_callback
+        )
     logger.info("Setup backends: {}".format([backend.name for backend in backend_modules]))
     return backend_modules
 
 
-def load_frontends(config, callback, internal_attributes):
+def load_frontends(config, auth_callback, logout_callback, internal_attributes):
     """
     Load all frontend modules specified in the config
 
     :type config: satosa.satosa_config.SATOSAConfig
-    :type callback:
+    :type auth_callback:
+    (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
+    :type logout_callback:
     (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
     :type internal_attributes: dict[string, dict[str, str | list[str]]]
     :rtype: Sequence[satosa.frontends.base.FrontendModule]
 
     :param config: The configuration of the satosa proxy
-    :param callback: Function that will be called by the frontend after the authentication request
+    :param auth_callback: Function that will be called by the frontend after the authentication request
+    :param logout_callback: Function that will be called by the frontend after the logout request
     has been processed.
     :return: A list of frontend modules
     """
     frontend_modules = _load_plugins(config.get("CUSTOM_PLUGIN_MODULE_PATHS"), config["FRONTEND_MODULES"],
-                                     frontend_filter, config["BASE"], internal_attributes, callback)
+                                     frontend_filter, config["BASE"], internal_attributes, auth_callback,
+                                     logout_callback)
     logger.info("Setup frontends: {}".format([frontend.name for frontend in frontend_modules]))
     return frontend_modules
 
@@ -151,7 +160,7 @@ def _load_plugin_config(config):
             raise SATOSAConfigurationError("The configuration is corrupt.") from exc
 
 
-def _load_plugins(plugin_paths, plugins, plugin_filter, base_url, internal_attributes, callback):
+def _load_plugins(plugin_paths, plugins, plugin_filter, base_url, internal_attributes, auth_callback, logout_callback):
     """
     Loads endpoint plugins
 
@@ -178,7 +187,7 @@ def _load_plugins(plugin_paths, plugins, plugin_filter, base_url, internal_attri
             if module_class:
                 module_config = _replace_variables_in_plugin_module_config(plugin_config["config"], base_url,
                                                                            plugin_config["name"])
-                instance = module_class(callback, internal_attributes, module_config, base_url,
+                instance = module_class(auth_callback, logout_callback, internal_attributes, module_config, base_url,
                                         plugin_config["name"])
                 loaded_plugin_modules.append(instance)
     return loaded_plugin_modules

--- a/src/satosa/store.py
+++ b/src/satosa/store.py
@@ -1,0 +1,83 @@
+class Storage:
+    def __init__(self, config):
+        self.db_config = config["DATABASE"]
+
+
+class SessionStorage:
+    """
+    In-memory storage
+    """
+    def __init__(self, config):
+        super().__init__(config)
+        self.authn_responses = {}
+
+    def store_authn_resp(self, state, internal_resp):
+        self.authn_responses[state["SESSION_ID"]] = internal_resp.to_dict()
+
+    def get_authn_resp(self, state):
+        return self.authn_responses.get(state["SESSION_ID"])
+
+    def delete_session(self, state, response_id):
+        if self.authn_responses.get(state["SESSION_ID"]):
+            del self.authn_responses[state["SESSION_ID"]]
+
+
+from sqlalchemy.ext.declarative import declarative_base
+
+
+Base = declarative_base()
+
+class AuthnResponse(Base):
+    from sqlalchemy.dialects.postgresql import JSON
+    from sqlalchemy import Column, Integer, String
+
+    __tablename__ = 'authn_responses'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String)
+    authn_response = Column(JSON)
+
+
+class SessionStoragePDB(Storage):
+    """
+    PostgreSQL storage
+    """
+    
+    def __init__(self, config):
+        super().__init__(config)
+
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        HOST = self.db_config["host"]
+        PORT = self.db_config["port"]
+        DB_NAME = self.db_config["db_name"]
+        USER = self.db_config["user"]
+        PWD = self.db_config["password"]
+
+        engine = create_engine(f"postgresql://{USER}:{PWD}@{HOST}:{PORT}/{DB_NAME}")
+        Base.metadata.create_all(engine)
+        self.Session = sessionmaker(bind=engine)
+
+    def store_authn_resp(self, state, internal_resp):
+        session = self.Session()
+        auth_response = AuthnResponse(
+            session_id=state["SESSION_ID"],
+            authn_response=(internal_resp.to_dict())
+        )   
+        session.add(auth_response)
+        session.commit()
+        session.close()
+
+    def get_authn_resp(self, state):
+        session = self.Session()
+        authn_response = session.query(AuthnResponse).filter(
+            AuthnResponse.session_id == state["SESSION_ID"]).all()
+        session.close()
+        authn_response = vars(authn_response[-1])["authn_response"]
+        return authn_response
+
+    def delete_session(self, state, response_id):
+        session = self.Session()
+        session.query(AuthnResponse).filter_by(id=response_id).delete()
+        session.commit()
+        session.close()


### PR DESCRIPTION
This PR introduces SAML Single Logout and allows the proxy to handle logout initiated at a SAML Service Provider.

## Changes

- Register `single_logout_service` methods to endpoints
- Register logout_callback functions
- Add functions to handle logout requests and logout responses
- Add a database to store session information required for logout

### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [ ] Have you added an explanation of what problem you are trying to solve with this PR?
- [x] Have you added information on what your changes do and why you chose this as your solution?
- [ ] Have you written new tests for your changes?
- [ ] Does your submission pass tests?
- [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


