### PR TITLE
backends/saml2: gracefully handle mismatching ACS

### DIFF
--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -21,6 +21,7 @@ from saml2.s_utils import deflate_and_base64_encode
 
 from satosa.backends.saml2 import SAMLBackend
 from satosa.context import Context
+from satosa.exception import SATOSAAuthenticationError
 from satosa.internal import InternalData
 from tests.users import USERS
 from tests.util import FakeIdP, create_metadata_from_config_dict, FakeSP
@@ -241,13 +242,11 @@ class TestSAMLBackend:
 
     def test_authn_response(self, context, idp_conf, sp_conf):
         response_binding = BINDING_HTTP_REDIRECT
-        fakesp = FakeSP(SPConfig().load(sp_conf))
-        fakeidp = FakeIdP(USERS, config=IdPConfig().load(idp_conf))
-        destination, request_params = fakesp.make_auth_req(idp_conf["entityid"])
-        url, auth_resp = fakeidp.handle_auth_req(request_params["SAMLRequest"], request_params["RelayState"],
-                                                 BINDING_HTTP_REDIRECT,
-                                                 "testuser1", response_binding=response_binding)
-
+        request_params, auth_resp = self._perform_request_response(
+            idp_conf,
+            sp_conf,
+            response_binding
+        )
         context.request = auth_resp
         context.state[self.samlbackend.name] = {"relay_state": request_params["RelayState"]}
         self.samlbackend.authn_response(context, response_binding)
@@ -256,29 +255,53 @@ class TestSAMLBackend:
         assert_authn_response(internal_resp)
         assert self.samlbackend.name not in context.state
 
+    def _perform_request_response(
+        self, idp_conf, sp_conf, response_binding, receive_nameid=True
+    ):
+        fakesp = FakeSP(SPConfig().load(sp_conf))
+        fakeidp = FakeIdP(USERS, config=IdPConfig().load(idp_conf))
+        destination, request_params = fakesp.make_auth_req(idp_conf["entityid"])
+        auth_resp_func = (
+            fakeidp.handle_auth_req
+            if receive_nameid
+            else fakeidp.handle_auth_req_no_name_id
+        )
+        url, auth_resp = auth_resp_func(
+            request_params["SAMLRequest"],
+            request_params["RelayState"],
+            BINDING_HTTP_REDIRECT,
+            "testuser1",
+            response_binding=response_binding,
+        )
+
+        return request_params, auth_resp
+
+    def test_no_relay_state_raises_error(self, context, idp_conf, sp_conf):
+        response_binding = BINDING_HTTP_REDIRECT
+        request_params, auth_resp = self._perform_request_response(
+            idp_conf,
+            sp_conf,
+            response_binding
+        )
+        context.request = auth_resp
+        # not setting context.state[self.samlbackend.name] to simulate a request
+        # without a session id
+
+        with pytest.raises(SATOSAAuthenticationError):
+            self.samlbackend.authn_response(context, response_binding)
+
     @pytest.mark.skipif(
             saml2.__version__ < '4.6.1',
             reason="Optional NameID needs pysaml2 v4.6.1 or higher")
     def test_authn_response_no_name_id(self, context, idp_conf, sp_conf):
         response_binding = BINDING_HTTP_REDIRECT
 
-        fakesp_conf = SPConfig().load(sp_conf)
-        fakesp = FakeSP(fakesp_conf)
-
-        fakeidp_conf = IdPConfig().load(idp_conf)
-        fakeidp = FakeIdP(USERS, config=fakeidp_conf)
-
-        destination, request_params = fakesp.make_auth_req(
-            idp_conf["entityid"])
-
-        # Use the fake IdP to mock up an authentication request that has no
-        # <NameID> element.
-        url, auth_resp = fakeidp.handle_auth_req_no_name_id(
-            request_params["SAMLRequest"],
-            request_params["RelayState"],
-            BINDING_HTTP_REDIRECT,
-            "testuser1",
-            response_binding=response_binding)
+        request_params, auth_resp = self._perform_request_response(
+            idp_conf,
+            sp_conf,
+            response_binding,
+            receive_nameid=False,
+        )
 
         backend = self.samlbackend
 


### PR DESCRIPTION
This is a new attempt to solve #324 . The error message specifically targets the administrator / logs. Even though the exception message has an assumption (the original relay state might be missing for other, more unlikely reasons), but drawing the admin's attention to the mismatching request address and ACS address is a good idea in this case, IMHO.

Commit message follows:

When the IdP redirects to an ACS which has a different address than the one we used for initiating the request, we are unable to verify the RelayState, since the browser does not send the session cookie. In order to make configuration debugging easier, raise an explanatory SATOSAAuthenticationError instead of a KeyError.

While adding a unit test to check for the proper error reporting, some code duplication was refactored.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


