### PR TITLE
feat: process multiple values of the resource query param

### DIFF
--- a/src/satosa/proxy_server.py
+++ b/src/satosa/proxy_server.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 def parse_query_string(data):
     query_param_pairs = _parse_query_string(data)
     query_param_dict = dict(query_param_pairs)
+    if "resource" in query_param_dict:
+        query_param_dict["resource"] = [t[1] for t in query_param_pairs if t[0] == "resource"]
     return query_param_dict
 
 


### PR DESCRIPTION
Changed the parsing of the query parameters so that in case of more than one occurrence of the same parameter, the value in the dictionary gets converted to a list, and additional values are appended. This allows sending an array value in the queries (useful, for example, with the "resource" parameter in the authorization requests). 

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


