### PR TITLE
feat: allow loading of tuples from YAML configs

### DIFF
--- a/src/satosa/yaml.py
+++ b/src/satosa/yaml.py
@@ -43,9 +43,21 @@ def _constructor_envfile_variables(loader, node):
         return new_value
 
 
+def _constructor_tuple_variables(loader, node):
+    """
+    Extracts the tuple variable from the node's value.
+    :param yaml.Loader loader: the yaml loader
+    :param node: the current node in the yaml
+    :return: value of the tuple
+    """
+    return tuple(loader.construct_sequence(node))
+
+
 TAG_ENV = "!ENV"
 TAG_ENVFILE = "!ENVFILE"
+TAG_TUPLE = u'tag:yaml.org,2002:python/tuple'
 
 
 _safe_loader.add_constructor(TAG_ENV, _constructor_env_variables)
 _safe_loader.add_constructor(TAG_ENVFILE, _constructor_envfile_variables)
+_safe_loader.add_constructor(TAG_TUPLE, _constructor_tuple_variables)

--- a/src/satosa/yaml.py
+++ b/src/satosa/yaml.py
@@ -55,7 +55,7 @@ def _constructor_tuple_variables(loader, node):
 
 TAG_ENV = "!ENV"
 TAG_ENVFILE = "!ENVFILE"
-TAG_TUPLE = u'tag:yaml.org,2002:python/tuple'
+TAG_TUPLE = "tag:yaml.org,2002:python/tuple"
 
 
 _safe_loader.add_constructor(TAG_ENV, _constructor_env_variables)


### PR DESCRIPTION
Currently it is not possible to supply storage for SAML frontend (pysaml2), because Safeloader is used and it prevents tuples from being loading as proper Python tuples.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


