### PR TITLE
fix: prevent endless loop from accessing self

### DIFF
--- a/src/satosa/internal.py
+++ b/src/satosa/internal.py
@@ -35,7 +35,7 @@ class _Datafy(UserDict):
 
     def __getattr__(self, key):
         if key == "data":
-            return self.data
+            return super().data
 
         try:
             value = self.__getitem__(key)


### PR DESCRIPTION
Fix to prevent endless loop when `self.data` calls `self.__getattr__`

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


