### PR TITLE
fix: do not access missing props in Apple backend

### DIFF
--- a/src/satosa/backends/apple.py
+++ b/src/satosa/backends/apple.py
@@ -113,11 +113,10 @@ class AppleBackend(OpenIDConnectBackend):
 
         # convert "string or Boolean" claims to actual booleans
         for bool_claim_name in ["email_verified", "is_private_email"]:
-            userinfo[bool_claim_name] = (
-                True
-                if userinfo[bool_claim_name] == "true"
-                else False
-            )
+            if type(all_user_claims.get(bool_claim_name)) == str:
+                all_user_claims[bool_claim_name] = (
+                    True if all_user_claims[bool_claim_name] == "true" else False
+                )
 
         msg = "UserInfo: {}".format(all_user_claims)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)


### PR DESCRIPTION
Introduced in #427, sorry @c00kiemon5ter I have missed that you have removed the guarding condition. The properties are not always present and might be already boolean, in which case the previous code converts `False` to `True`.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?
