### PR TITLE
new: add microservice to expose info about IdP from SAML metadata as attributes

### DIFF
--- a/example/plugins/microservices/metadata_attributes.yaml.example
+++ b/example/plugins/microservices/metadata_attributes.yaml.example
@@ -1,0 +1,21 @@
+module: satosa.micro_services.attribute_modifications.AddMetadataAttributes
+name: AddMetadataAttributes
+config:
+    attribute_mapping:
+        - name: shibmd_scopes
+          type: shibmd_scopes
+        - name: contact_person_data
+          type: contact_person_data
+        - name: assurance_certifications
+          type: assurance_certifications
+        - name: registration_info
+          type: registration_info
+        - name: registration_authority
+          type: registration_authority
+        - name: entity_categories
+          type: entity_categories
+        - name: supported_entity_categories
+          type: supported_entity_categories
+        - name: entity_attributes
+          type: entity_attributes
+


### PR DESCRIPTION

Primary goal was to expose registration_authority for services connected to eduGAIN.

Generalised to expose all possibly useful info available from MDStore.

Notable decisions:
* while registration_authority is included in registration_info data structure, exposing it directly should make it easier for applications to consume and process the value.
* to expose scopes, it was necessary to revert the regex_compile step done when regexp="true" (as Pattern objects are not seriazable)
* tuple objects are not serializable and had to be converted to a list
* mod_auth_openidc does not accept lists of complex types as claim value, assuming this might also apply to other RP implementations, wrap the listt a dict to match other attributes.

Please let me know what you think @c00kiemon5ter - happy to add tests once I get the overall OK.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


