### PR TITLE
Handle multiple back/front-ends

### DIFF
--- a/src/satosa/metadata_creation/saml_metadata.py
+++ b/src/satosa/metadata_creation/saml_metadata.py
@@ -169,3 +169,19 @@ def create_entity_descriptor_metadata(entity_descriptor, valid_for=None):
         entity_descriptor.valid_until = in_a_while(hours=valid_for)
 
     return str(entity_descriptor)
+
+def create_entities_descriptor(entity_descriptors, valid_for=None):
+    """
+    :param entity_descriptors: the entity descriptors to put in in an EntitiesDescriptor
+    :param valid_for: number of hours the metadata should be valid
+    :return: the EntitiesDescriptor metadata
+
+    :type entity_descriptors: Sequence[saml2.md.EntityDescriptor]]
+    :type valid_for: Optional[int]
+    """
+    entities_desc, xmldoc = entities_descriptor(entity_descriptors, valid_for=valid_for, name=None, ident=None,
+                                                sign=False, secc=None)
+    if not valid_instance(entities_desc):
+        raise ValueError("Could not construct valid EntitiesDescriptor tag")
+
+    return str(entities_desc)

--- a/src/satosa/scripts/satosa_saml_metadata.py
+++ b/src/satosa/scripts/satosa_saml_metadata.py
@@ -5,7 +5,9 @@ from saml2.config import Config
 from saml2.sigver import security_context
 
 from ..metadata_creation.saml_metadata import create_entity_descriptors
+from ..metadata_creation.saml_metadata import create_entities_descriptor
 from ..metadata_creation.saml_metadata import create_entity_descriptor_metadata
+from ..metadata_creation.saml_metadata import create_signed_entities_descriptor
 from ..metadata_creation.saml_metadata import create_signed_entity_descriptor
 from ..satosa_config import SATOSAConfig
 
@@ -33,14 +35,14 @@ def _create_split_entity_descriptors(entities, secc, valid, sign=True):
 
 def _create_merged_entities_descriptors(entities, secc, valid, name, sign=True):
     output = []
-    frontend_entity_descriptors = [e for sublist in entities.values() for e in sublist]
-    for frontend in frontend_entity_descriptors:
-        ed_str = (
-            create_signed_entity_descriptor(frontend, secc, valid)
-            if sign
-            else create_entity_descriptor_metadata(frontend, valid)
-        )
-        output.append((ed_str, name))
+    entity_descriptors = [e for sublist in entities.values() for e in sublist]
+
+    ed_str = (
+        create_signed_entities_descriptor(entity_descriptors, secc, valid)
+        if sign
+        else create_entities_descriptor(entity_descriptors, valid)
+    )
+    output.append((ed_str, name))
 
     return output
 


### PR DESCRIPTION
Without this fix only the last back/front-end will be written to file if split is not involved.

Add new method create_entities_descriptor as a counterpart to create_signed_entity_descriptor to also apply `valid` option to EntititesDescriptor but avoiding signing.

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


