### PR TITLE
Use a selected backend in metadata

### DIFF
--- a/src/satosa/metadata_creation/saml_metadata.py
+++ b/src/satosa/metadata_creation/saml_metadata.py
@@ -86,8 +86,11 @@ def _create_frontend_metadata(frontend_modules, backend_modules):
                     frontend_metadata[frontend.name].append(entity_desc)
 
         elif isinstance(frontend, SAMLFrontend):
-            frontend.register_endpoints([backend.name for
-                                         backend in backend_modules])
+            if "preferred_backend_in_metadata" in frontend.config["idp_config"]:
+                frontend.register_endpoints([frontend.config["idp_config"]["preferred_backend_in_metadata"]])
+            else:
+                frontend.register_endpoints([backend.name for
+                                             backend in backend_modules])
             entity_desc = _create_entity_descriptor(frontend.idp_config)
             frontend_metadata[frontend.name].append(entity_desc)
 


### PR DESCRIPTION
If multiple backends are available we want to be able to specify one when creating the metadata with `satosa_saml_metadata`. Otherwise all available backend appears in `SingleSignOnService` for the frontend.

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


