### PR TITLE
Support paths in BASE during routing

### DIFF
--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -33,6 +33,11 @@ config:
   sub_hash_salt: randomSALTvalue
 
   provider:
+    # If you do not specify the issuer here, then BASE will be used as Issuer.
+    # Note that even though this setting must be specified as a full URL,
+    # provider discovery will only work, if the request can be routed back to
+    # SATOSA.
+    issuer: https://op.example.com/satosa/OIDC
     client_registration_supported: Yes
     response_types_supported: ["code", "id_token token"]
     subject_types_supported: ["pairwise"]

--- a/example/plugins/frontends/openid_connect_frontend.yaml.example
+++ b/example/plugins/frontends/openid_connect_frontend.yaml.example
@@ -33,11 +33,7 @@ config:
   sub_hash_salt: randomSALTvalue
 
   provider:
-    # If you do not specify the issuer here, then BASE will be used as Issuer.
-    # Note that even though this setting must be specified as a full URL,
-    # provider discovery will only work, if the request can be routed back to
-    # SATOSA.
-    issuer: https://op.example.com/satosa/OIDC
+    issuer: <base_url>
     client_registration_supported: Yes
     response_types_supported: ["code", "id_token token"]
     subject_types_supported: ["pairwise"]

--- a/src/satosa/backends/base.py
+++ b/src/satosa/backends/base.py
@@ -3,6 +3,9 @@ Holds a base class for backend modules used in the SATOSA proxy.
 """
 
 from ..attribute_mapping import AttributeMapper
+from ..util import join_paths
+
+from urllib.parse import urlparse
 
 
 class BackendModule(object):
@@ -29,8 +32,11 @@ class BackendModule(object):
         self.auth_callback_func = auth_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/") if base_url else ""
+        self.base_path = urlparse(self.base_url).path.lstrip("/")
         self.name = name
+        self.endpoint_baseurl = join_paths(self.base_url, self.name)
+        self.endpoint_basepath = urlparse(self.endpoint_baseurl).path.lstrip("/")
 
     def start_auth(self, context, internal_request):
         """

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 
 from saml2.s_utils import UnknownSystemEntity
+from urllib.parse import urlparse
 
 from satosa import util
 from satosa.response import BadRequest
@@ -52,6 +53,8 @@ class SATOSABase(object):
         """
         self.config = config
 
+        base_path = urlparse(self.config["BASE"]).path.lstrip("/")
+
         logger.info("Loading backend modules...")
         backends = load_backends(self.config, self._auth_resp_callback_func,
                                  self.config["INTERNAL_ATTRIBUTES"])
@@ -77,8 +80,10 @@ class SATOSABase(object):
                                             self.config["BASE"]))
             self._link_micro_services(self.response_micro_services, self._auth_resp_finish)
 
-        self.module_router = ModuleRouter(frontends, backends,
-                                          self.request_micro_services + self.response_micro_services)
+        self.module_router = ModuleRouter(frontends,
+                                          backends,
+                                          self.request_micro_services + self.response_micro_services,
+                                          base_path)
 
     def _link_micro_services(self, micro_services, finisher):
         if not micro_services:

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -70,10 +70,6 @@ class Context(object):
             raise ValueError("path can't start with '/'")
         self._path = p
 
-    def target_entity_id_from_path(self):
-        target_entity_id = self.path.split("/")[1]
-        return target_entity_id
-
     def decorate(self, key, value):
         """
         Add information to the context

--- a/src/satosa/frontends/base.py
+++ b/src/satosa/frontends/base.py
@@ -2,6 +2,9 @@
 Holds a base class for frontend modules used in the SATOSA proxy.
 """
 from ..attribute_mapping import AttributeMapper
+from ..util import join_paths
+
+from urllib.parse import urlparse
 
 
 class FrontendModule(object):
@@ -14,17 +17,23 @@ class FrontendModule(object):
         :type auth_req_callback_func:
         (satosa.context.Context, satosa.internal.InternalData) -> satosa.response.Response
         :type internal_attributes: dict[str, dict[str, str | list[str]]]
+        :type base_url: str
         :type name: str
 
         :param auth_req_callback_func: Callback should be called by the module after the
         authorization response has been processed.
+        :param internal_attributes: attribute mapping
+        :param base_url: base url of the proxy
         :param name: name of the plugin
         """
         self.auth_req_callback_func = auth_req_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
-        self.base_url = base_url
+        self.base_url = base_url or ""
+        self.base_path = urlparse(self.base_url).path.lstrip("/")
         self.name = name
+        self.endpoint_baseurl = join_paths(self.base_url, self.name)
+        self.endpoint_basepath = urlparse(self.endpoint_baseurl).path.lstrip("/")
 
     def handle_authn_response(self, context, internal_resp):
         """

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -37,7 +37,7 @@ from .base import FrontendModule
 from ..response import BadRequest, Created
 from ..response import SeeOther, Response
 from ..response import Unauthorized
-from ..util import rndstr
+from ..util import join_paths, rndstr
 
 import satosa.logging_util as lu
 from satosa.internal import InternalData
@@ -97,7 +97,6 @@ class OpenIDConnectFrontend(FrontendModule):
         else:
             cdb = {}
 
-        self.endpoint_baseurl = "{}/{}".format(self.base_url, self.name)
         self.provider = _create_provider(
             provider_config,
             self.endpoint_baseurl,
@@ -173,6 +172,19 @@ class OpenIDConnectFrontend(FrontendModule):
         :rtype: list[(str, ((satosa.context.Context, Any) -> satosa.response.Response, Any))]
         :raise ValueError: if more than one backend is configured
         """
+        # See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
+        #
+        # We skip the scheme + host + port of the issuer URL, because we can only map the
+        # path for the provider config endpoint. We are safe to use urlparse().path here,
+        # because for issuer OIDC allows only https URLs without query and fragment parts.
+        issuer = self.provider.configuration_information["issuer"]
+        autoconf_path = ".well-known/openid-configuration"
+        provider_config = (
+            "^{}$".format(join_paths(urlparse(issuer).path.lstrip("/"), autoconf_path)),
+            self.provider_config,
+        )
+        jwks_uri = ("^{}/jwks$".format(self.endpoint_basepath), self.jwks)
+
         backend_name = None
         if len(backend_names) != 1:
             # only supports one backend since there currently is no way to publish multiple authorization endpoints
@@ -189,40 +201,49 @@ class OpenIDConnectFrontend(FrontendModule):
         else:
             backend_name = backend_names[0]
 
-        provider_config = ("^.well-known/openid-configuration$", self.provider_config)
-        jwks_uri = ("^{}/jwks$".format(self.name), self.jwks)
-
         if backend_name:
             # if there is only one backend, include its name in the path so the default routing can work
-            auth_endpoint = "{}/{}/{}/{}".format(self.base_url, backend_name, self.name, AuthorizationEndpoint.url)
+            auth_endpoint = join_paths(
+                self.base_url,
+                backend_name,
+                self.name,
+                AuthorizationEndpoint.url,
+            )
             self.provider.configuration_information["authorization_endpoint"] = auth_endpoint
             auth_path = urlparse(auth_endpoint).path.lstrip("/")
         else:
-            auth_path = "{}/{}".format(self.name, AuthorizationEndpoint.url)
+            auth_path = join_paths(self.endpoint_basepath, AuthorizationRequest.url)
 
         authentication = ("^{}$".format(auth_path), self.handle_authn_request)
         url_map = [provider_config, jwks_uri, authentication]
 
         if any("code" in v for v in self.provider.configuration_information["response_types_supported"]):
-            self.provider.configuration_information["token_endpoint"] = "{}/{}".format(
-                self.endpoint_baseurl, TokenEndpoint.url
+            self.provider.configuration_information["token_endpoint"] = join_paths(
+                self.endpoint_baseurl,
+                TokenEndpoint.url,
             )
             token_endpoint = (
-                "^{}/{}".format(self.name, TokenEndpoint.url), self.token_endpoint
+                "^{}".format(join_paths(self.endpoint_basepath, TokenEndpoint.url)),
+                self.token_endpoint,
             )
             url_map.append(token_endpoint)
 
             self.provider.configuration_information["userinfo_endpoint"] = (
-                "{}/{}".format(self.endpoint_baseurl, UserinfoEndpoint.url)
+                join_paths(self.endpoint_baseurl, UserinfoEndpoint.url)
             )
             userinfo_endpoint = (
-                "^{}/{}".format(self.name, UserinfoEndpoint.url), self.userinfo_endpoint
+                "^{}".format(
+                    join_paths(self.endpoint_basepath, UserinfoEndpoint.url)
+                ),
+                self.userinfo_endpoint,
             )
             url_map.append(userinfo_endpoint)
 
         if "registration_endpoint" in self.provider.configuration_information:
             client_registration = (
-                "^{}/{}".format(self.name, RegistrationEndpoint.url),
+                "^{}".format(
+                    join_paths(self.endpoint_basepath, RegistrationEndpoint.url)
+                ),
                 self.client_registration,
             )
             url_map.append(client_registration)

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -62,7 +62,8 @@ class OpenIDConnectFrontend(FrontendModule):
 
         self.config = conf
         provider_config = self.config["provider"]
-        provider_config["issuer"] = base_url
+        if not provider_config.get("issuer"):
+            provider_config["issuer"] = base_url
 
         self.signing_key = RSAKey(
             key=rsa_load(self.config["signing_key_path"]),

--- a/src/satosa/frontends/ping.py
+++ b/src/satosa/frontends/ping.py
@@ -3,6 +3,7 @@ import logging
 import satosa.logging_util as lu
 from satosa.frontends.base import FrontendModule
 from satosa.response import Response
+from satosa.util import join_paths
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ class PingFrontend(FrontendModule):
         :rtype: list[(str, ((satosa.context.Context, Any) -> satosa.response.Response, Any))]
         :raise ValueError: if more than one backend is configured
         """
-        url_map = [("^{}".format(self.name), self.ping_endpoint)]
+        url_map = [("^{}".format(join_paths(self.endpoint_basepath, self.name)), self.ping_endpoint)]
 
         return url_map
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -33,6 +33,7 @@ from .base import FrontendModule
 from ..response import Response
 from ..response import ServiceError
 from ..saml_util import make_saml_response
+from ..util import join_paths
 from satosa.exception import SATOSAError
 from satosa.exception import SATOSABadRequestError
 from satosa.exception import SATOSAMissingStateError
@@ -119,7 +120,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
 
         if self.enable_metadata_reload():
             url_map.append(
-                ("^%s/%s$" % (self.name, "reload-metadata"), self._reload_metadata))
+                ("^%s/%s$" % (self.endpoint_basepath, "reload-metadata"), self._reload_metadata))
 
         self.idp_config = self._build_idp_config_endpoints(
             self.config[self.KEY_IDP_CONFIG], backend_names)
@@ -553,15 +554,20 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         """
         url_map = []
 
+        backend_providers = "(" + "|".join(providers) + ")"
         for endp_category in self.endpoints:
             for binding, endp in self.endpoints[endp_category].items():
-                valid_providers = ""
-                for provider in providers:
-                    valid_providers = "{}|^{}".format(valid_providers, provider)
-                valid_providers = valid_providers.lstrip("|")
-                parsed_endp = urlparse(endp)
-                url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
-                                functools.partial(self.handle_authn_request, binding_in=binding)))
+                endp_path = urlparse(endp).path
+                url_map.append(
+                    (
+                        "^{}$".format(
+                            join_paths(self.base_path, backend_providers, endp_path)
+                        ),
+                        functools.partial(
+                            self.handle_authn_request, binding_in=binding
+                        ),
+                    )
+                )
 
         if self.expose_entityid_endpoint():
             logger.debug("Exposing frontend entity endpoint = {}".format(self.idp.config.entityid))
@@ -717,10 +723,17 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :param context:
         :return: An idp server
         """
-        target_entity_id = context.target_entity_id_from_path()
+        target_entity_id = self._target_entity_id_from_path(context.path)
         idp_conf_file = self._load_endpoints_to_config(context.target_backend, target_entity_id)
         idp_config = IdPConfig().load(idp_conf_file)
         return Server(config=idp_config)
+
+    def _target_entity_id_from_path(self, request_path):
+        path = request_path.lstrip("/")
+        base_path = urlparse(self.base_url).path.lstrip("/")
+        if base_path and path.startswith(base_path):
+            path = path[len(base_path):].lstrip("/")
+        return path.split("/")[1]
 
     def _load_idp_dynamic_entity_id(self, state):
         """
@@ -747,7 +760,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :type binding_in: str
         :rtype: satosa.response.Response
         """
-        target_entity_id = context.target_entity_id_from_path()
+        target_entity_id = self._target_entity_id_from_path(context.path)
         target_entity_id = urlsafe_b64decode(target_entity_id).decode()
         context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
 
@@ -765,7 +778,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :rtype: dict[str, dict[str, str] | str]
         """
         state = super()._create_state_data(context, resp_args, relay_state)
-        state["target_entity_id"] = context.target_entity_id_from_path()
+        state["target_entity_id"] = self._target_entity_id_from_path(context.path)
         return state
 
     def handle_backend_error(self, exception):
@@ -800,14 +813,20 @@ class SAMLMirrorFrontend(SAMLFrontend):
         """
         url_map = []
 
+        backend_providers = "(" + "|".join(providers) + ")"
         for endp_category in self.endpoints:
             for binding, endp in self.endpoints[endp_category].items():
-                valid_providers = "|^".join(providers)
-                parsed_endp = urlparse(endp)
+                endp_path = urlparse(endp).path
                 url_map.append(
                     (
-                        r"(^{})/\S+/{}".format(valid_providers, parsed_endp.path),
-                        functools.partial(self.handle_authn_request, binding_in=binding)
+                        "^{}$".format(
+                            join_paths(
+                                self.base_path, backend_providers, "\S+", endp_path
+                            )
+                        ),
+                        functools.partial(
+                            self.handle_authn_request, binding_in=binding
+                        ),
                     )
                 )
 

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -12,6 +12,7 @@ from satosa.internal import InternalData
 from ..exception import SATOSAAuthenticationError
 from ..micro_services.base import ResponseMicroService
 from ..response import Redirect
+from ..util import join_paths
 
 import satosa.logging_util as lu
 logger = logging.getLogger(__name__)
@@ -161,4 +162,11 @@ class AccountLinking(ResponseMicroService):
 
         :return: A list of endpoints bound to a function
         """
-        return [("^account_linking%s$" % self.endpoint, self._handle_al_response)]
+        return [
+            (
+                "^{}$".format(
+                    join_paths(self.base_path, "account_linking", self.endpoint)
+                ),
+                self._handle_al_response,
+            )
+        ]

--- a/src/satosa/micro_services/base.py
+++ b/src/satosa/micro_services/base.py
@@ -2,6 +2,9 @@
 Micro service for SATOSA
 """
 import logging
+from urllib.parse import urlparse
+
+from ..util import join_paths
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,9 @@ class MicroService(object):
     def __init__(self, name, base_url, **kwargs):
         self.name = name
         self.base_url = base_url
+        self.base_path = urlparse(base_url).path.lstrip("/")
+        self.endpoint_baseurl = join_paths(self.base_url, self.name)
+        self.endpoint_basepath = urlparse(self.endpoint_baseurl).path.lstrip("/")
         self.next = None
 
     def process(self, context, data):

--- a/src/satosa/micro_services/consent.py
+++ b/src/satosa/micro_services/consent.py
@@ -16,6 +16,7 @@ import satosa.logging_util as lu
 from satosa.internal import InternalData
 from satosa.micro_services.base import ResponseMicroService
 from satosa.response import Redirect
+from satosa.util import join_paths
 
 
 logger = logging.getLogger(__name__)
@@ -238,4 +239,11 @@ class Consent(ResponseMicroService):
 
         :return: A list of endpoints bound to a function
         """
-        return [("^consent%s$" % self.endpoint, self._handle_consent_response)]
+        return [
+            (
+                "^{}$".format(
+                    join_paths(self.base_path, "consent", self.endpoint)
+                ),
+                self._handle_consent_response,
+            )
+        ]

--- a/src/satosa/routing.py
+++ b/src/satosa/routing.py
@@ -24,11 +24,12 @@ class ModuleRouter(object):
     and handles the internal routing between frontends and backends.
     """
 
-    def __init__(self, frontends, backends, micro_services):
+    def __init__(self, frontends, backends, micro_services, base_path=None):
         """
         :type frontends: dict[str, satosa.frontends.base.FrontendModule]
         :type backends: dict[str, satosa.backends.base.BackendModule]
         :type micro_services: Sequence[satosa.micro_services.base.MicroService]
+        :type base_path: str
 
         :param frontends: All available frontends used by the proxy. Key as frontend name, value as
         module
@@ -36,6 +37,7 @@ class ModuleRouter(object):
         module
         :param micro_services: All available micro services used by the proxy. Key as micro service name, value as
         module
+        :param base_path: Base path for endpoint mapping
         """
 
         if not frontends or not backends:
@@ -53,6 +55,8 @@ class ModuleRouter(object):
                                    for instance in micro_services}
         else:
             self.micro_services = {}
+
+        self.base_path = base_path if base_path else ""
 
         logger.debug("Loaded backends with endpoints: {}".format(backends))
         logger.debug("Loaded frontends with endpoints: {}".format(frontends))
@@ -120,6 +124,19 @@ class ModuleRouter(object):
 
         raise ModuleRouter.UnknownEndpoint(context.path)
 
+    def _find_backend(self, request_path):
+        """
+        Tries to guess the backend in use from the request.
+        Returns the backend name or None if the backend was not specified.
+        """
+        request_path = request_path.lstrip("/")
+        if self.base_path and request_path.startswith(self.base_path):
+            request_path = request_path[len(self.base_path):].lstrip("/")
+        backend_guess = request_path.split("/")[0]
+        if backend_guess in self.backends:
+            return backend_guess
+        return None
+
     def endpoint_routing(self, context):
         """
         Finds and returns the endpoint function bound to the path
@@ -141,13 +158,12 @@ class ModuleRouter(object):
         msg = "Routing path: {path}".format(path=context.path)
         logline = lu.LOG_FMT.format(id=lu.get_session_id(context.state), message=msg)
         logger.debug(logline)
-        path_split = context.path.split("/")
-        backend = path_split[0]
 
-        if backend in self.backends:
+        backend = self._find_backend(context.path)
+        if backend is not None:
             context.target_backend = backend
         else:
-            msg = "Unknown backend {}".format(backend)
+            msg = "No backend was specified in request or no such backend {}".format(backend)
             logline = lu.LOG_FMT.format(
                 id=lu.get_session_id(context.state), message=msg
             )
@@ -156,6 +172,8 @@ class ModuleRouter(object):
         try:
             name, frontend_endpoint = self._find_registered_endpoint(context, self.frontends)
         except ModuleRouter.UnknownEndpoint:
+            for frontend in self.frontends.values():
+                logger.debug(f"Unable to find {context.path} in {frontend['endpoints']}")
             pass
         else:
             context.target_frontend = name
@@ -169,7 +187,7 @@ class ModuleRouter(object):
             context.target_micro_service = name
             return micro_service_endpoint
 
-        if backend in self.backends:
+        if backend is not None:
             backend_endpoint = self._find_registered_backend_endpoint(context)
             if backend_endpoint:
                 return backend_endpoint

--- a/src/satosa/util.py
+++ b/src/satosa/util.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import random
 import string
+import typing
 
 
 logger = logging.getLogger(__name__)
@@ -89,3 +90,25 @@ def rndstr(size=16, alphabet=""):
     if not alphabet:
         alphabet = string.ascii_letters[0:52] + string.digits
     return type(alphabet)().join(rng.choice(alphabet) for _ in range(size))
+
+
+def join_paths(*paths, sep: typing.Optional[str] = None) -> str:
+    """
+    Joins strings with a separator like they were path components. The
+    separator is stripped off from all path components, except for the
+    beginning of the first component. Empty (or falsy) components are skipped.
+    Note that the components are not sanitized in any other way.
+
+    Raises TypeError if any of the components are not strings (or empty).
+    """
+    sep = sep or "/"
+    leading = ""
+    if paths and paths[0] and paths[0][0] == sep:
+        leading = sep
+
+    try:
+        return leading + sep.join(
+            path.strip(sep) for path in filter(lambda p: p and p.strip(sep), paths)
+        )
+    except (AttributeError, TypeError) as err:
+        raise TypeError("Arguments must be strings") from err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from satosa.state import State
 from .util import create_metadata_from_config_dict
 from .util import generate_cert, write_cert
 
-BASE_URL = "https://test-proxy.com"
+BASE_URL = "https://test-proxy.com/satosa"
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +38,7 @@ def cert_and_key(tmpdir):
 
 @pytest.fixture
 def sp_conf(cert_and_key):
-    sp_base = "http://example.com"
+    sp_base = "http://example.com/test"
     spconfig = {
         "entityid": "{}/unittest_sp.xml".format(sp_base),
         "service": {
@@ -64,7 +64,7 @@ def sp_conf(cert_and_key):
 
 @pytest.fixture
 def idp_conf(cert_and_key):
-    idp_base = "http://idp.example.com"
+    idp_base = "http://idp.example.com/test"
 
     idpconfig = {
         "entityid": "{}/{}/proxy.xml".format(idp_base, "Saml2IDP"),
@@ -136,7 +136,23 @@ def satosa_config_dict(backend_plugin_config, frontend_plugin_config, request_mi
         "BACKEND_MODULES": [backend_plugin_config],
         "FRONTEND_MODULES": [frontend_plugin_config],
         "MICRO_SERVICES": [request_microservice_config, response_microservice_config],
-        "LOGGING": {"version": 1}
+        "LOGGING": {
+            "version": 1,
+            "handlers": {
+                "stdout": {
+                    "level": "DEBUG",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "simple",
+                }
+            },
+            "loggers": {"satosa": {"level": "DEBUG"}},
+            "formatters": {
+                "simple": {
+                    "format": "[%(asctime)s] [%(levelname)s] [%(name)s.%(funcName)s] %(message)s"
+                }
+            },
+        }
     }
     return config
 

--- a/tests/flows/test_account_linking.py
+++ b/tests/flows/test_account_linking.py
@@ -1,9 +1,11 @@
 import responses
+from urllib.parse import urlparse
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
 from satosa.proxy_server import make_app
 from satosa.satosa_config import SATOSAConfig
+from satosa.util import join_paths
 
 
 class TestAccountLinking:
@@ -13,6 +15,7 @@ class TestAccountLinking:
         account_linking_module_config["config"]["api_url"] = api_url
         account_linking_module_config["config"]["redirect_url"] = redirect_url
         satosa_config_dict["MICRO_SERVICES"].insert(0, account_linking_module_config)
+        base_path = urlparse(satosa_config_dict["BASE"]).path.lstrip("\n/")
 
         # application
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
@@ -36,5 +39,5 @@ class TestAccountLinking:
             rsps.add(responses.GET, "{}/get_id".format(api_url), "test_userid", status=200)
 
             # incoming account linking response
-            http_resp = test_client.get("/account_linking/handle_account_linking")
+            http_resp = test_client.get(join_paths("/", base_path, "account_linking/handle_account_linking"))
             assert http_resp.status_code == 200

--- a/tests/flows/test_consent.py
+++ b/tests/flows/test_consent.py
@@ -2,11 +2,13 @@ import json
 import re
 
 import responses
+from urllib.parse import urlparse
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
 from satosa.proxy_server import make_app
 from satosa.satosa_config import SATOSAConfig
+from satosa.util import join_paths
 
 
 class TestConsent:
@@ -16,6 +18,7 @@ class TestConsent:
         consent_module_config["config"]["api_url"] = api_url
         consent_module_config["config"]["redirect_url"] = redirect_url
         satosa_config_dict["MICRO_SERVICES"].append(consent_module_config)
+        base_path = urlparse(satosa_config_dict["BASE"]).path.lstrip("\n/")
 
         # application
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
@@ -43,5 +46,5 @@ class TestConsent:
             rsps.add(responses.GET, verify_url_re, json.dumps({"foo": "bar"}), status=200)
 
             # incoming consent response
-            http_resp = test_client.get("/consent/handle_consent")
+            http_resp = test_client.get(join_paths("/", base_path, "consent/handle_consent"))
             assert http_resp.status_code == 200

--- a/tests/flows/test_oidc-saml.py
+++ b/tests/flows/test_oidc-saml.py
@@ -28,7 +28,7 @@ CLIENT_SECRET = "secret"
 CLIENT_REDIRECT_URI = "https://client.example.com/cb"
 REDIRECT_URI = "https://client.example.com/cb"
 DB_URI = "mongodb://localhost/satosa"
-EXTRA_ISSUER = "https://other-op.example.com/satosa/other/op"
+EXTRA_ISSUER = "<base_url>/other/op"
 
 @pytest.fixture(scope="session")
 def client_db_path(tmpdir_factory):
@@ -117,7 +117,7 @@ class TestOIDCToSAML:
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
 
         # get frontend OP config info
-        issuer = EXTRA_ISSUER
+        issuer = EXTRA_ISSUER.replace("<base_url>", satosa_config_dict["BASE"])
         provider_config = self._discover_provider(test_client, issuer)
 
         # create auth req

--- a/tests/flows/test_oidc-saml.py
+++ b/tests/flows/test_oidc-saml.py
@@ -28,6 +28,7 @@ CLIENT_SECRET = "secret"
 CLIENT_REDIRECT_URI = "https://client.example.com/cb"
 REDIRECT_URI = "https://client.example.com/cb"
 DB_URI = "mongodb://localhost/satosa"
+EXTRA_ISSUER = "https://other-op.example.com/satosa/other/op"
 
 @pytest.fixture(scope="session")
 def client_db_path(tmpdir_factory):
@@ -104,6 +105,7 @@ class TestOIDCToSAML:
         subject_id = "testuser1"
 
         # proxy config
+        oidc_frontend_config["config"]["provider"]["issuer"] = EXTRA_ISSUER
         satosa_config_dict["FRONTEND_MODULES"] = [oidc_frontend_config]
         satosa_config_dict["BACKEND_MODULES"] = [saml_backend_config]
         satosa_config_dict["INTERNAL_ATTRIBUTES"]["attributes"] = {attr_name: {"openid": [attr_name],
@@ -115,7 +117,7 @@ class TestOIDCToSAML:
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
 
         # get frontend OP config info
-        issuer = satosa_config_dict["BASE"]
+        issuer = EXTRA_ISSUER
         provider_config = self._discover_provider(test_client, issuer)
 
         # create auth req

--- a/tests/satosa/frontends/test_openid_connect.py
+++ b/tests/satosa/frontends/test_openid_connect.py
@@ -44,6 +44,7 @@ EXTRA_CLAIMS = {
 EXTRA_SCOPES = {
     "eduperson": ["eduperson_scoped_affiliation", "eduperson_principal_name"]
 }
+ISSUER = "https://other-op.example.com/satosa/other-op"
 
 class TestOpenIDConnectFrontend(object):
     @pytest.fixture
@@ -392,6 +393,16 @@ class TestOpenIDConnectFrontend(object):
         assert (
             "^{}/{}".format(frontend.endpoint_basepath, UserinfoEndpoint.url),
             frontend.userinfo_endpoint,
+        ) in urls
+
+    def test_discovery_endpoint_honours_issuer_override(self, frontend_config):
+        frontend_config["provider"]["issuer"] = ISSUER
+        frontend = self.create_frontend(frontend_config)
+        discovery_path = urlparse(ISSUER).path[1:]
+        urls = frontend.register_endpoints(["test"])
+        assert (
+            "^{}/{}$".format(discovery_path, ".well-known/openid-configuration"),
+            frontend.provider_config,
         ) in urls
 
     def test_register_endpoints_token_and_userinfo_endpoint_is_not_published_if_only_implicit_flow(

--- a/tests/satosa/test_util.py
+++ b/tests/satosa/test_util.py
@@ -1,0 +1,47 @@
+import pytest
+from satosa.util import join_paths
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (["/foo", "baz", "bar"], "/foo/baz/bar"),
+        (["foo", "baz", "bar"], "foo/baz/bar"),
+        (["https://foo.baz", "bar"], "https://foo.baz/bar"),
+        (["https://foo.baz/", "bar"], "https://foo.baz/bar"),
+        (["foo", "/bar"], "foo/bar"),
+        (["/foo", "baz", "/bar"], "/foo/baz/bar"),
+        (["", "foo", "bar"], "foo/bar"),
+        (["", "/foo", "bar"], "foo/bar"),
+        (["", "/foo/", "bar"], "foo/bar"),
+        (["", "", "", "/foo", "bar"], "foo/bar"),
+        (["", "", "/foo/", "", "bar"], "foo/bar"),
+        (["", "", "/foo/", "", "", "bar/"], "foo/bar"),
+        (["/foo", ""], "/foo"),
+        (["/foo", "", "", ""], "/foo"),
+        (["/foo//", "bar"], "/foo/bar"),
+        (["foo"], "foo"),
+        ([""], ""),
+        (["", ""], ""),
+        (["'not ", "sanitized'\0/; rm -rf *"], "'not /sanitized'\0/; rm -rf *"),
+        (["foo/", "/bar"], "foo/bar"),
+        (["foo", "", "/bar"], "foo/bar"),
+        ([b"foo", "bar"], TypeError),
+        (["foo", b"bar"], TypeError),
+        ([None, "foo"], "foo"),
+        (["foo", [], "bar"], "foo/bar"),
+        (["foo", ["baz"], "bar"], TypeError),
+        (["/", "foo", "bar"], "/foo/bar"),
+        (["///foo", "bar"], "/foo/bar"),
+    ],
+)
+def test_join_paths(args, expected):
+    if isinstance(expected, str):
+        assert join_paths(*args) == expected
+    else:
+        with pytest.raises(expected):
+            _ = join_paths(*args)
+
+
+def test_join_paths_with_separator():
+    assert join_paths("this", "is", "not", "a", "path", sep="|") == "this|is|not|a|path"


### PR DESCRIPTION
This is a squashed and slightly polished variant of #405 .
Original description follows:

> If Satosa is installed under a path which is not the root of the
> webserver (ie. "https://example.com/satosa"), then endpoint routing must
> take the base path into consideration.
> 
> Some modules registered some of their endpoints with the base path
> included, but other times the base path was omitted, thus it made the
> routing fail. Now all endpoint registrations include the base path in
> their endpoint map.
> 
> Additionally, DEBUG logging was configured for the tests so that the
> debug logs are accessible during testing.
> 
> Fixes #404

