### PR TITLE
Workaround for xmlsec breaking when SHA1 is deprecated: Allow signature and digest algorithm as parameters ...

### DIFF
--- a/src/satosa/metadata_creation/saml_metadata.py
+++ b/src/satosa/metadata_creation/saml_metadata.py
@@ -134,11 +134,14 @@ def create_signed_entities_descriptor(entity_descriptors, security_context, vali
     return xmldoc
 
 
-def create_signed_entity_descriptor(entity_descriptor, security_context, valid_for=None):
+def create_signed_entity_descriptor(entity_descriptor, security_context, valid_for=None, sign_alg=None,
+                                    digest_alg=None):
     """
     :param entity_descriptor: the entity descriptor to sign
     :param security_context: security context for the signature
     :param valid_for: number of hours the metadata should be valid
+    :param sign_alg: signature algorithm from saml2.xmldsig
+    :param digest_alg: digest algorithm from saml2.xmldsig
     :return: the signed XML document
 
     :type entity_descriptor: saml2.md.EntityDescriptor]
@@ -148,7 +151,9 @@ def create_signed_entity_descriptor(entity_descriptor, security_context, valid_f
     if valid_for:
         entity_descriptor.valid_until = in_a_while(hours=valid_for)
 
-    entity_desc, xmldoc = sign_entity_descriptor(entity_descriptor, None, security_context)
+    entity_desc, xmldoc = sign_entity_descriptor(entity_descriptor, None, security_context,
+                                                 sign_alg=sign_alg,
+                                                 digest_alg=digest_alg)
 
     if not valid_instance(entity_desc):
         raise ValueError("Could not construct valid EntityDescriptor tag")


### PR DESCRIPTION
... for metadata generation. Also using sha256 as default to prevent xmlsec breaking on systems where sha1 is disabled.

## Details

Pull allows for additional parameters --signature-algorithm and --digest-algorithm in scripts/saml_metadata.py which are applied when signing is true (the default).
Given Strings should reference xmldsig (mirroring frontend/backend configuration) like "SIG_RSA_SHA256".

## Change of behavior

Defaults in scripts/saml_metadata.py select SHA256 instead of SHA1 (SHA1 is just the default in pysaml2) to avoid metadata generation breaking on systems where SHA1 is already deprecated and thus xmlsec1 unable to sign metadata. Which was the reason for the change in the first place (RHEL9).

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?