### PR TITLE
add WSGIPassAuthorization directive to Apache configuration

### DIFF
--- a/doc/mod_wsgi.md
+++ b/doc/mod_wsgi.md
@@ -95,6 +95,9 @@ WSGIScriptAlias / /usr/lib/python3.4/site-packages/satosa/wsgi.py
 WSGICallableObject app
 WSGIImportScript /usr/lib/python3.4/site-packages/satosa/wsgi.py \
   process-group=satosa application-group=satosa
+
+# ensure authorization headers are transmitted to the application
+WSGIPassAuthorization On
 ```
 
 ## SATOSA Configuration


### PR DESCRIPTION
I spend a few hours debugging this token endpoint authentification issue, which is espcially painful as only basic authentifcation is supported.

For the record, here are the following symptoms:
```
[satosa.frontends.openid_connect.token_endpoint] invalid client authentication at token endpoint
...
pyop.exceptions.InvalidClientAuthentication: client_id 'None' unknown
```


