### PR TITLE
BaseProcessor: add missing 'self'

### DIFF
--- a/src/satosa/micro_services/processors/base_processor.py
+++ b/src/satosa/micro_services/processors/base_processor.py
@@ -2,5 +2,5 @@ class BaseProcessor(object):
     def __init__(self):
         pass
 
-    def process(internal_data, attribute, **kwargs):
+    def process(self, internal_data, attribute, **kwargs):
         pass


### PR DESCRIPTION
The `BaseProcessor.process` method is missing its `self` argument. I stumbled upon this while writing a custom attribute processor because pylint complained that I was overriding a method with a differing number of arguments.
