### PR TITLE
ACR Mapping Documentation Changes

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -241,8 +241,8 @@ provider will be preserved, and when using a OAuth or OpenID Connect backend, th
 config:
     [...]
     acr_mapping:
-        "": default-LoA
-        "https://accounts.google.com": LoA1
+        "": "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified"
+        "https://accounts.google.com": "http://eidas.europa.eu/LoA/low"
 ```
 
 ### SAML2 Frontend

--- a/example/plugins/backends/saml2_backend.yaml.example
+++ b/example/plugins/backends/saml2_backend.yaml.example
@@ -4,8 +4,8 @@ config:
   idp_blacklist_file: /path/to/blacklist.json
 
   acr_mapping:
-    "": default-LoA
-    "https://accounts.google.com": LoA1
+    "": "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified"
+    "https://accounts.google.com": "http://eidas.europa.eu/LoA/low"
 
   # disco_srv must be defined if there is more than one IdP in the metadata specified above
   disco_srv: http://disco.example.com

--- a/example/plugins/frontends/saml2_frontend.yaml.example
+++ b/example/plugins/frontends/saml2_frontend.yaml.example
@@ -2,8 +2,8 @@ module: satosa.frontends.saml2.SAMLFrontend
 name: Saml2IDP
 config:
   #acr_mapping:
-  #  "": default-LoA
-  #  "https://accounts.google.com": LoA1
+  #  "": "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified"
+  #  "https://accounts.google.com": "http://eidas.europa.eu/LoA/low"
 
   endpoints:
     single_sign_on_service:

--- a/example/plugins/frontends/saml2_virtualcofrontend.yaml.example
+++ b/example/plugins/frontends/saml2_virtualcofrontend.yaml.example
@@ -91,8 +91,8 @@ config:
             lifetime: {minutes: 15}
             name_form: urn:oasis:names:tc:SAML:2.0:attrname-format:uri
   acr_mapping:
-    "": default-LoA
-    "https://accounts.google.com": LoA1
+    "": "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified"
+    "https://accounts.google.com": "http://eidas.europa.eu/LoA/low"
 
   endpoints:
     single_sign_on_service:


### PR DESCRIPTION
Per spec on page 22 in https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf authentication context class references should be valid URIs. While I think there's little value to parsing an ACR as a URI and validating it's in that format, some SAML libraries do and the proxied assertion will fail at the relying party.

I'd recommend using urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified as the example for fallback mapping in acr_mapping documentation and indicating that other mappings should be valid URIs as well. I'm not tied to any particular mapping choice, I'd just like the examples to be well-formed URIs to save users some potential debugging.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?


