### PR TITLE
fix crash when user ID attribute is missing from reply

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -151,11 +151,11 @@ class SATOSABase(object):
 
         # If configured construct the user id from attribute values.
         if "user_id_from_attrs" in self.config["INTERNAL_ATTRIBUTES"]:
-            subject_id = [
-                "".join(internal_response.attributes[attr]) for attr in
-                self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]
-            ]
-            internal_response.subject_id = "".join(subject_id)
+            subject_id = ""
+            for attr in self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]:
+                if attr in internal_response.attributes:
+                    subject_id += internal_response.attributes[attr]
+            internal_response.subject_id = subject_id
 
         if self.response_micro_services:
             return self.response_micro_services[0].process(


### PR DESCRIPTION
When an attribute listed in user_id_from_attrs is missing from SAML reply, SATOSA crashes when building subject_id.

Contrarily to what the comment says (This function is called by a backend module when the authorization is  complete), this function seem called before authorization is checked, as making those attribute mandatory in attributes_authorization.yaml is not enough to prevent the crash.

        