### PR TITLE
add WSGIPassAuthorization directive to Apache configuration

### DIFF
--- a/doc/mod_wsgi.md
+++ b/doc/mod_wsgi.md
@@ -95,6 +95,9 @@ WSGIScriptAlias / /usr/lib/python3.4/site-packages/satosa/wsgi.py
 WSGICallableObject app
 WSGIImportScript /usr/lib/python3.4/site-packages/satosa/wsgi.py \
   process-group=satosa application-group=satosa
+
+# ensure authorization headers are transmitted to the application
+WSGIPassAuthorization On
 ```
 
 ## SATOSA Configuration


### PR DESCRIPTION
The WSGIPassAuthorization directive seems mandatory, but is missing from the sample Apache confguration example.