### PR TITLE
fix crash when user ID attribute is missing from reply

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -151,10 +151,10 @@ class SATOSABase(object):
 
         # If configured construct the user id from attribute values.
         if "user_id_from_attrs" in self.config["INTERNAL_ATTRIBUTES"]:
-            subject_id = [
-                "".join(internal_response.attributes[attr]) for attr in
-                self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]
-            ]
+            subject_id = []
+            for attr in self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]:
+                if attr in internal_response.attributes:
+                    subject_id.append("".join(internal_response.attributes[attr]))
             internal_response.subject_id = "".join(subject_id)
 
         if self.response_micro_services:


### PR DESCRIPTION
If one of the attributes mentionned in user_id_from_attrs is missing from the IdP answer, SATOSA will crash with the following exception (missing attribute is called sub in this specific case):

[2025-01-10 10:16:08,259] [ERROR] [satosa.proxy_server.__call__] Unknown error
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/satosa/base.py", line 268, in run
    resp = self._run_bound_endpoint(context, spec)
  File "/usr/local/lib/python3.9/site-packages/satosa/base.py", line 193, in _run_bound_endpoint
    return spec(context)
  File "/usr/local/lib/python3.9/site-packages/satosa/backends/saml2.py", line 482, in authn_response
    return self.auth_callback_func(context, self._translate_response(authn_response, context.state))
  File "/usr/local/lib/python3.9/site-packages/satosa/base.py", line 154, in _auth_resp_callback_func
    subject_id = ""
  File "/usr/local/lib/python3.9/site-packages/satosa/base.py", line 155, in <listcomp>
    for attr in self.config["INTERNAL_ATTRIBUTES"]["user_id_from_attrs"]:
KeyError: 'sub'

This PR fixes this issue by ensuring missing attributes are skipped.